### PR TITLE
renamed the diagnoses label + reconfigured styling for 1 line

### DIFF
--- a/src/bento/globalStatsData.js
+++ b/src/bento/globalStatsData.js
@@ -18,7 +18,7 @@ export const statsStyling = {
     padding: '0.1% 6% 2% 6%',
     borderRight: '1px solid #0B3556',
     '&:first-child': {
-      padding: '0.1% 6% 2% 6%',
+      padding: '0.1% 3% 2% 6%',
     },
     '&:last-child': {
       padding: '0.1% 6% 2% 6%',
@@ -56,7 +56,7 @@ export const statsStyling = {
 export const globalStatsData = [
   // A maximum of 6 stats are allowed
   {
-    statTitle: 'Diagnoses',
+    statTitle: 'Diagnosis Records',
     type: 'field',
     statAPI: 'numberOfDiagnoses',
     statIconSrc: diagnosisLogo,

--- a/src/pages/landing/landingView.js
+++ b/src/pages/landing/landingView.js
@@ -34,7 +34,7 @@ const LandingView = ({ classes, statsData }) => (
                         </div>
                       </div>
                       <div className={classes.statsBubbleText}>
-                        Diagnoses
+                        Diagnosis Records
                       </div>
                       <div className={classes.statsBubbleDiagnosesIcon}>
                         <img 


### PR DESCRIPTION
[C3DC-455](https://tracker.nci.nih.gov/browse/C3DC-455)

Temporary name change for diagnoses in the stats bar + padding change to keep text in one line