### PR TITLE
Unsaved Changes provide warning before attempted to leave the modal

### DIFF
--- a/src/pages/inventory/cohortModal/CohortModalContext.js
+++ b/src/pages/inventory/cohortModal/CohortModalContext.js
@@ -5,9 +5,10 @@ export const CohortModalContext = createContext();
 export const CohortModalProvider = ({ children }) => {
   const [showCohortModal, setShowCohortModal] = useState(false);
   const [warningMessage, setWarningMessage] = useState("");
+  const [currentCohortChanges, setCurrentCohortChanges] = useState(null);
 
   return (
-    <CohortModalContext.Provider value={{ showCohortModal, setShowCohortModal, warningMessage, setWarningMessage }}>
+    <CohortModalContext.Provider value={{ showCohortModal, setShowCohortModal, warningMessage, setWarningMessage, currentCohortChanges, setCurrentCohortChanges }}>
       {children}
     </CohortModalContext.Provider>
   );

--- a/src/pages/inventory/cohortModal/cohortModalGenerator.js
+++ b/src/pages/inventory/cohortModal/cohortModalGenerator.js
@@ -95,7 +95,8 @@ export const CohortModalGenerator = (uiConfig = DEFAULT_CONFIG) => {
             cohortId: localCohort.cohortId,
             cohortName: localCohort.cohortName,
             cohortDescription: localCohort.cohortDescription,
-            participants: localCohort.participants
+            participants: localCohort.participants,
+            searchText: localCohort.searchText,
         })
     };
 

--- a/src/pages/inventory/cohortModal/cohortModalGenerator.js
+++ b/src/pages/inventory/cohortModal/cohortModalGenerator.js
@@ -12,10 +12,13 @@ import DEFAULT_STYLES from './styles';
 import DEFAULT_CONFIG from './config';
 import CohortList from './components/cohortList';
 import CohortDetails from './components/cohortDetails';
+import DeleteConfirmationModal from './components/deleteConfirmationModal';
+import { deletionTypes } from './components/deleteConfirmationModal';
 import Alert from '@material-ui/lab/Alert';
 import { GET_COHORT_MANIFEST_QUERY, GET_COHORT_METADATA_QUERY } from '../../../bento/dashboardTabData.js';
 import client from '../../../utils/graphqlClient.js'
-import { arrayToCSVDownload, objectToJsonDownload } from './utils.js';
+import { arrayToCSVDownload, objectToJsonDownload, hasUnsavedChanges } from './utils.js';
+import { CohortModalContext } from './CohortModalContext.js'
 
 /**
  * Generator function to create cohortModal component with custom configuration
@@ -29,9 +32,16 @@ export const CohortModalGenerator = (uiConfig = DEFAULT_CONFIG) => {
         config, functions,
     } = uiConfig;
 
+    const { currentCohortChanges, setCurrentCohortChanges } = useContext(CohortModalContext);
     const { state, dispatch } = useContext(CohortStateContext);
     const [selectedCohort, setSelectedCohort] = useState(null); // Default to the first entry
     const [alert, setAlert] = useState({ type: '', message: '' });
+    const unSavedChanges = currentCohortChanges ? hasUnsavedChanges(currentCohortChanges, state[selectedCohort]) : false;
+    const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+    const [deleteModalProps, setDeleteModalProps] = useState({
+        handleDelete: () => { },
+        deletionType: "",
+    });
     useEffect(() => {
         if (alert.message) {
             const timer = setTimeout(() => {
@@ -79,6 +89,20 @@ export const CohortModalGenerator = (uiConfig = DEFAULT_CONFIG) => {
         dispatch(onDeleteAllCohort());
     };
     // Handle saving updates to cohort
+    const handleSetCurrentCohortChanges = (localCohort) => {
+        if (!localCohort.cohortId) return;
+        setCurrentCohortChanges({
+            cohortId: localCohort.cohortId,
+            cohortName: localCohort.cohortName,
+            cohortDescription: localCohort.cohortDescription,
+            participants: localCohort.participants
+        })
+    };
+
+    const handleClearCurrentCohortChanges = () => {
+        setCurrentCohortChanges(null);
+    };
+
     const handleSaveCohort = (localCohort) => {
         if (!localCohort.cohortId) return;
         dispatch(onMutateSingleCohort(
@@ -88,7 +112,10 @@ export const CohortModalGenerator = (uiConfig = DEFAULT_CONFIG) => {
                 cohortDescription: localCohort.cohortDescription,
                 participants: localCohort.participants
             },
-            () => setAlert({ type: 'success', message: 'Cohort updated successfully!' }),
+            () => {
+                setAlert({ type: 'success', message: 'Cohort updated successfully!' })
+                handleClearCurrentCohortChanges();
+            },
             (error) => setAlert({ type: 'error', message: `Failed to update cohort: ${error.message}` })
         ));
     };
@@ -113,54 +140,82 @@ export const CohortModalGenerator = (uiConfig = DEFAULT_CONFIG) => {
                 setSelectedCohort(null);
             };
 
+            const unSavedChangesCheck = () => {
+                if (unSavedChanges) {
+                    setDeleteModalProps({
+                        handleDelete: () => closeModalWrapper(),
+                        deletionType: deletionTypes.CLEAR_UNSAVED_CHANGES,
+                    });
+                    setShowDeleteConfirmation(true)
+                }
+                else {
+                    closeModalWrapper()
+                }
+            }
+
             return (
-                <Modal
-                    {...props}
-                    open={open}
-                    className={classes.modal}
-                    onClose={closeModalWrapper}
-                >
-                    <div className={classes.paper}>
-                        <h1 className={classes.modalTitle}>
-                            <span>{modalTitle}</span>
-                            <span className={classes.closeIcon} onClick={closeModalWrapper}>
-                                <img
-                                    src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg"
-                                    alt="close icon"
-                                    className={classes.closeRoot}
+                <>
+                    <Modal
+                        {...props}
+                        open={open}
+                        className={classes.modal}
+                        onClose={unSavedChangesCheck}
+                    >
+                        <div className={classes.paper}>
+                            <h1 className={classes.modalTitle}>
+                                <span>{modalTitle}</span>
+                                <span className={classes.closeIcon} onClick={unSavedChangesCheck}>
+                                    <img
+                                        src="https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/bento/images/icons/svgs/LocalFindCaseDeleteIcon.svg"
+                                        alt="close icon"
+                                        className={classes.closeRoot}
+                                    />
+                                </span>
+                                {alert.message && (
+                                    <Alert severity={alert.type} className={classes.alert} onClose={() => setAlert({ type: '', message: '' })}>
+                                        {alert.message}
+                                    </Alert>
+                                )}
+                            </h1>
+                            <div className={classes.modalContainer}>
+                                <CohortList
+                                    classes={cohortListClasses}
+                                    config={config.cohortList}
+                                    selectedCohort={selectedCohort}
+                                    setSelectedCohort={setSelectedCohort}
+                                    unSavedChanges={unSavedChanges}
+                                    setChangingConfirmation={setDeleteModalProps}
+                                    setShowChangingConfirmation={setShowDeleteConfirmation}
+                                    closeParentModal={unSavedChangesCheck}
+                                    handleDeleteCohort={handleDeleteCohort}
+                                    handleDeleteAllCohorts={handleDeleteAllCohorts}
+                                    handleClearCurrentCohortChanges={handleClearCurrentCohortChanges}
+                                    deleteConfirmationClasses={deleteConfirmationClasses}
+                                    state={state}
                                 />
-                            </span>
-                            {alert.message && (
-                                <Alert severity={alert.type} className={classes.alert} onClose={() => setAlert({ type: '', message: '' })}>
-                                    {alert.message}
-                                </Alert>
-                            )}
-                        </h1>
-                        <div className={classes.modalContainer}>
-                            <CohortList
-                                classes={cohortListClasses}
-                                config={config.cohortList}
-                                selectedCohort={selectedCohort}
-                                setSelectedCohort={setSelectedCohort}
-                                closeParentModal={closeModalWrapper}
-                                handleDeleteCohort={handleDeleteCohort}
-                                handleDeleteAllCohorts={handleDeleteAllCohorts}
-                                deleteConfirmationClasses={deleteConfirmationClasses}
-                                state={state}
-                            />
-                            <CohortDetails
-                                classes={cohortDetailsClasses}
-                                config={config.cohortDetails}
-                                activeCohort={state[selectedCohort]}
-                                closeModal={closeModalWrapper}
-                                handleSaveCohort={handleSaveCohort}
-                                downloadCohortManifest={downloadCohortManifest}
-                                downloadCohortMetadata={downloadCohortMetadata}
-                                deleteConfirmationClasses={deleteConfirmationClasses}
-                            />
+                                <CohortDetails
+                                    classes={cohortDetailsClasses}
+                                    config={config.cohortDetails}
+                                    activeCohort={state[selectedCohort]}
+                                    temporaryCohort={currentCohortChanges}
+                                    closeModal={unSavedChangesCheck}
+                                    handleSaveCohort={handleSaveCohort}
+                                    handleSetCurrentCohortChanges={handleSetCurrentCohortChanges}
+                                    downloadCohortManifest={downloadCohortManifest}
+                                    downloadCohortMetadata={downloadCohortMetadata}
+                                    deleteConfirmationClasses={deleteConfirmationClasses}
+                                />
+                            </div>
                         </div>
-                    </div>
-                </Modal>
+                    </Modal>
+                    <DeleteConfirmationModal
+                        classes={deleteConfirmationClasses}
+                        open={showDeleteConfirmation}
+                        setOpen={setShowDeleteConfirmation}
+                        handleDelete={deleteModalProps.handleDelete}
+                        deletionType={deleteModalProps.deletionType}
+                    />
+                </>
             )
         }),
     };

--- a/src/pages/inventory/cohortModal/components/cohortDetails.js
+++ b/src/pages/inventory/cohortModal/components/cohortDetails.js
@@ -19,8 +19,10 @@ const CohortDetails = (props) => {
         classes,
         config,
         activeCohort,
+        temporaryCohort,
         closeModal,
         handleSaveCohort,
+        handleSetCurrentCohortChanges,
         downloadCohortManifest,
         downloadCohortMetadata,
         deleteConfirmationClasses,
@@ -30,14 +32,16 @@ const CohortDetails = (props) => {
         return null;
     }
 
+    let matchingCohortID = temporaryCohort && temporaryCohort.cohortId === activeCohort.cohortId;
+
     const [selectedColumn, setSelectedColumn] = useState(['participant_id', 'ascending']);
     const [searchText, setSearchText] = useState('');
 
     const [localCohort, setLocalCohort] = useState({
-        cohortId: activeCohort.cohortId,
-        cohortName: activeCohort.cohortName,
-        cohortDescription: activeCohort.cohortDescription,
-        participants: JSON.parse(JSON.stringify(activeCohort.participants)),
+        cohortId: matchingCohortID ? temporaryCohort.cohortId : activeCohort.cohortId,
+        cohortName: matchingCohortID ? temporaryCohort.cohortName : activeCohort.cohortName,
+        cohortDescription: matchingCohortID ? temporaryCohort.cohortDescription : activeCohort.cohortDescription,
+        participants: matchingCohortID ? JSON.parse(JSON.stringify(temporaryCohort.participants)) : JSON.parse(JSON.stringify(activeCohort.participants)),
     });
     const [isEditingName, setIsEditingName] = useState(false);
     const [isEditingDescription, setIsEditingDescription] = useState(false);
@@ -94,12 +98,20 @@ const CohortDetails = (props) => {
         setIsEditingDescription(true);
     };
 
-    const handleSaveName = () => {
+    const handleSaveName = (e) => {
         setIsEditingName(false);
+        handleSetCurrentCohortChanges({
+            ...localCohort,
+            [e.target.name]: e.target.value,
+        });
     };
 
-    const handleSaveDescription = () => {
+    const handleSaveDescription = (e) => {
         setIsEditingDescription(false);
+        handleSetCurrentCohortChanges({
+            ...localCohort,
+            [e.target.name]: e.target.value,
+        });
     };
 
     const handleDownloadDropdown = () => {
@@ -132,10 +144,18 @@ const CohortDetails = (props) => {
             ...localCohort,
             participants: localCohort.participants.filter(participant => participant.participant_pk !== participant_pk),
         });
+        handleSetCurrentCohortChanges({
+            ...localCohort,
+            participants: localCohort.participants.filter(participant => participant.participant_pk !== participant_pk),
+        });
     };
 
     const handleDeleteAllParticipants = () => {
         setLocalCohort({
+            ...localCohort,
+            participants: [],
+        });
+        handleSetCurrentCohortChanges({
             ...localCohort,
             participants: [],
         });
@@ -198,7 +218,7 @@ const CohortDetails = (props) => {
                                 type="text"
                                 name="cohortName"
                                 value={localCohort['cohortName']}
-                                onBlur={handleSaveName}
+                                onBlur={(e) => handleSaveName(e)}
                                 onChange={(e) => handleTextChange(e)}
                                 maxLength={20}
                                 autoFocus
@@ -223,7 +243,7 @@ const CohortDetails = (props) => {
                         <textarea
                         className={classes.editingCohortDescription}
                         value={localCohort['cohortDescription']}
-                        onBlur={handleSaveDescription}
+                        onBlur={(e) => handleSaveDescription(e)}
                         name="cohortDescription"
                         onChange={(e) => handleTextChange(e)}
                         rows={2}

--- a/src/pages/inventory/cohortModal/components/cohortDetails.js
+++ b/src/pages/inventory/cohortModal/components/cohortDetails.js
@@ -35,7 +35,7 @@ const CohortDetails = (props) => {
     let matchingCohortID = temporaryCohort && temporaryCohort.cohortId === activeCohort.cohortId;
 
     const [selectedColumn, setSelectedColumn] = useState(['participant_id', 'ascending']);
-    const [searchText, setSearchText] = useState('');
+    const [searchText, setSearchText] = useState(matchingCohortID && temporaryCohort['searchText'] ? temporaryCohort['searchText'] : '');
 
     const [localCohort, setLocalCohort] = useState({
         cohortId: matchingCohortID ? temporaryCohort.cohortId : activeCohort.cohortId,
@@ -101,6 +101,7 @@ const CohortDetails = (props) => {
     const handleSaveName = (e) => {
         setIsEditingName(false);
         handleSetCurrentCohortChanges({
+            ...temporaryCohort,
             ...localCohort,
             [e.target.name]: e.target.value,
         });
@@ -109,8 +110,17 @@ const CohortDetails = (props) => {
     const handleSaveDescription = (e) => {
         setIsEditingDescription(false);
         handleSetCurrentCohortChanges({
+            ...temporaryCohort,
             ...localCohort,
             [e.target.name]: e.target.value,
+        });
+    };
+
+    const handleSetSearch = (e) => {
+        handleSetCurrentCohortChanges({
+            ...temporaryCohort,
+            ...localCohort,
+            searchText: e.target.value,
         });
     };
 
@@ -145,6 +155,7 @@ const CohortDetails = (props) => {
             participants: localCohort.participants.filter(participant => participant.participant_pk !== participant_pk),
         });
         handleSetCurrentCohortChanges({
+            ...temporaryCohort,
             ...localCohort,
             participants: localCohort.participants.filter(participant => participant.participant_pk !== participant_pk),
         });
@@ -156,6 +167,7 @@ const CohortDetails = (props) => {
             participants: [],
         });
         handleSetCurrentCohortChanges({
+            ...temporaryCohort,
             ...localCohort,
             participants: [],
         });
@@ -269,6 +281,7 @@ const CohortDetails = (props) => {
                             className={classes.participantSearchBar}
                             value={searchText}
                             onChange={(e) => setSearchText(e.target.value)}
+                            onBlur={(e) => handleSetSearch(e)}
                         />
                         <span className={classes.searchIcon}>
                             <img

--- a/src/pages/inventory/cohortModal/components/cohortList.js
+++ b/src/pages/inventory/cohortModal/components/cohortList.js
@@ -17,9 +17,13 @@ const CohortList = (props) => {
         config,
         selectedCohort,
         setSelectedCohort,
+        unSavedChanges,
+        setChangingConfirmation,
+        setShowChangingConfirmation,
         closeParentModal,
         handleDeleteCohort,
         handleDeleteAllCohorts,
+        handleClearCurrentCohortChanges,
         state,
     } = props;
 
@@ -109,7 +113,20 @@ const CohortList = (props) => {
                                 key={state[cohort].cohortId}
                                 className={`${classes.cohortListItem} ${isSelected ? classes.selectedCohort : ''}`}
                                 onClick={() => {
-                                    setSelectedCohort(state[cohort].cohortId)
+                                    if (unSavedChanges){
+                                        setChangingConfirmation({
+                                            handleDelete: () => {
+                                                setSelectedCohort(state[cohort].cohortId)
+                                                handleClearCurrentCohortChanges();
+                                            },
+                                            deletionType: deletionTypes.CLEAR_UNSAVED_CHANGES,
+                                        });
+                                        setShowChangingConfirmation(true);
+                                    }
+                                    else {
+                                        setSelectedCohort(state[cohort].cohortId)
+                                        handleClearCurrentCohortChanges();
+                                    }
                                 }}
                             >
                                 <span className={classes.cohortListItemText}>

--- a/src/pages/inventory/cohortModal/components/cohortList.js
+++ b/src/pages/inventory/cohortModal/components/cohortList.js
@@ -113,6 +113,9 @@ const CohortList = (props) => {
                                 key={state[cohort].cohortId}
                                 className={`${classes.cohortListItem} ${isSelected ? classes.selectedCohort : ''}`}
                                 onClick={() => {
+                                    if (state[cohort].cohortId === selectedCohort){
+                                        return;
+                                    }
                                     if (unSavedChanges){
                                         setChangingConfirmation({
                                             handleDelete: () => {

--- a/src/pages/inventory/cohortModal/components/deleteConfirmationModal.js
+++ b/src/pages/inventory/cohortModal/components/deleteConfirmationModal.js
@@ -2,9 +2,10 @@ import React from 'react';
 import { Modal, withStyles } from '@material-ui/core';
 
 export const deletionTypes = {
-    DELETE_ALL_COHORTS: 'ALL cohorts',
-    DELETE_SINGLE_COHORT: 'this cohort',
-    DELETE_ALL_PARTICIPANTS: 'ALL participants',
+    DELETE_ALL_COHORTS: 'delete ALL cohorts?',
+    DELETE_SINGLE_COHORT: 'delete this cohort?',
+    DELETE_ALL_PARTICIPANTS: 'delete ALL participants?',
+    CLEAR_UNSAVED_CHANGES: 'leave? You will lose all unsaved changes.'
 };
 
 const DeleteConfirmationModal = (props) => {
@@ -28,8 +29,8 @@ const DeleteConfirmationModal = (props) => {
                             <span>{message}</span>
                             :
                             <>
-                                <span>Are you sure you want to delete {deletionType}? {deletionType !== deletionTypes.DELETE_ALL_PARTICIPANTS && 'This action cannot be undone.'}</span>
-                                <span>Press Confirm or Cancel.</span>
+                                <span> Are you sure you want to {deletionType} </span>
+                                {deletionType !== deletionTypes.DELETE_ALL_PARTICIPANTS && <span>This action cannot be undone.</span>}
                             </>
                         }
 

--- a/src/pages/inventory/cohortModal/utils.js
+++ b/src/pages/inventory/cohortModal/utils.js
@@ -93,3 +93,18 @@ export const objectToJsonDownload = (obj, cohortID) => {
     tempLink.click();
     document.body.removeChild(tempLink);
   };
+
+  export const hasUnsavedChanges = (obj1, obj2) => {
+    if (!obj1 || !obj2) return false; // If either object is undefined, consider no changes
+  
+    const sharedKeys = Object.keys(obj1).filter(key => key in obj2);
+    const filteredObj1 = sharedKeys.reduce((acc, key) => {
+        acc[key] = obj1[key];
+        return acc;
+    }, {});
+    const filteredObj2 = sharedKeys.reduce((acc, key) => {
+        acc[key] = obj2[key];
+        return acc;
+    }, {});
+    return JSON.stringify(filteredObj1) !== JSON.stringify(filteredObj2);
+  };

--- a/src/pages/inventory/tabs/TabsView.js
+++ b/src/pages/inventory/tabs/TabsView.js
@@ -14,7 +14,7 @@ const Tabs = (props) => {
     setCurrentTab(value);
   };
 
-  const { showCohortModal, setShowCohortModal , setWarningMessage, warningMessage} = useContext(CohortModalContext);
+  const { showCohortModal, setShowCohortModal , setWarningMessage, warningMessage } = useContext(CohortModalContext);
 
   /**
   * 1. change <name> to <display> as array item

--- a/src/pages/inventory/tabs/wrapperConfig/customButton.js
+++ b/src/pages/inventory/tabs/wrapperConfig/customButton.js
@@ -6,7 +6,6 @@ import { onCreateNewCohort } from '../../../../components/CohortSelectorState/st
 import { CohortStateContext } from '../../../../components/CohortSelectorState/CohortStateContext';
 import { CohortModalContext } from '../../cohortModal/CohortModalContext';
 import { onRowSelectHidden } from '@bento-core/paginated-table/dist/table/state/Actions';
-import DeleteConfirmationModal from '../../cohortModal/components/deleteConfirmationModal';
 
 const ButtonContainer = styled.div`
   position: relative;
@@ -54,10 +53,9 @@ export const CustomButton = ({ label, backgroundColor, type, hoverColor, cohorts
 
   const tableContext = useContext(TableContext);
   const { dispatch } = useContext(CohortStateContext);
-  const { setShowCohortModal, setWarningMessage} = useContext(CohortModalContext);
+  const { setShowCohortModal, setWarningMessage, setCurrentCohortChanges} = useContext(CohortModalContext);
   const { Notification } = useGlobal();
   const [isActive, setIsActive] = useState(false);
-  const [warning,setWarning] = useState("");
 
   const triggerNotification = (count) => {
     if (count > 1) {
@@ -95,12 +93,14 @@ export const CustomButton = ({ label, backgroundColor, type, hoverColor, cohorts
     if (isActive) {
       if (type === "VIEW") {
         setShowCohortModal(true);
+        setCurrentCohortChanges(null);
       } else {
         const { context } = tableContext;
         const {
           hiddenSelectedRows = []
         } = context;
         clearSelection();
+        setCurrentCohortChanges(null);
         dispatch(onCreateNewCohort(
           "",
           "",


### PR DESCRIPTION
[C3DC-1057](https://tracker.nci.nih.gov/browse/C3DC-1057)

- The context has been updated to account for the new state.
- The new state is prioritized when loading the right panel on refresh if it exists.
- When warning pop-up appears when trying to close the modal or change from the current modal.
- The search bar is preserved on refresh of the component if there are unsaved changes.
- When the user saves the changes, on success it clears the state, otherwise preserves it.
- Delete modal has new properties to account for this case (unsaved changes)