### PR TITLE
prevent double querying

### DIFF
--- a/src/pages/inventory/inventoryController.js
+++ b/src/pages/inventory/inventoryController.js
@@ -19,6 +19,7 @@ const getDashData = (states) => {
 
   const client = useApolloClient();
   async function getData(activeFilters) {
+    await client.clearStore();
     let result = await client.query({
       query: DASHBOARD_QUERY_NEW,
       variables: activeFilters,


### PR DESCRIPTION
[C3DC-1470](https://tracker.nci.nih.gov/browse/C3DC-1470)

The issue turns out to be that the query for the dashboard is ran twice but the initial query without the filter is slower. Once it finished it overrode the correct query with the filter's results.