### PR TITLE
updated the study table to reroute to study page on study name

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -1266,6 +1266,11 @@ export const tabContainers = [
         display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
+        linkAttr: {
+          rootPath: '/studies/',
+          linkField: 'dbgap_accession',
+        },
+        cellType: cellTypes.CUSTOM_ELEM,
       },
       {
         dataField: "study_description",

--- a/src/pages/inventory/tabs/tableConfig/Column.js
+++ b/src/pages/inventory/tabs/tableConfig/Column.js
@@ -67,18 +67,31 @@ export const CustomCellView = (props) => {
   }
 
   if (props.linkAttr) {
-    const { rootPath } = props.linkAttr;
-    return (
-      <Link
-        className={cellTypes.LINK}
-        href={`${rootPath}${label}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+    const { rootPath, linkField } = props.linkAttr;
+    //If the link requires another field, provide it in the linkField otherwise will use current field (label)
+    if (rootPath.startsWith('http://') || rootPath.startsWith('https://')) {
+      return (
+        <Link
+          className={cellTypes.LINK}
+          href={`${rootPath}${linkField ? props[linkField] : label}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
 
-        <Typography >{label}</Typography>
-      </Link>
-    )
+          <Typography >{label}</Typography>
+        </Link>
+      );
+    }
+    else {
+      return (
+        <Link
+          className={cellTypes.LINK}
+          href={`${rootPath}${linkField ? props[linkField] : label}`}
+        >
+          <Typography >{label}</Typography>
+        </Link>
+      );
+    }
   }
 
   if (Array.isArray(label)) {


### PR DESCRIPTION
Revised changes for [C3DC-1592](https://tracker.nci.nih.gov/browse/C3DC-1592)

- Added new linkField prop when creating URLs from another property of the table column
- Study table's 'study name' column now uses the dbgap accession's col data to redirect to the local study page for that study