### PR TITLE
C3DC-1598 top 20 limits on widgets

### DIFF
--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -568,6 +568,8 @@ export const widgetConfig = [
   },
 ];
 
+export const WIDGET_DATASET_LIMIT = 20;
+
 export const widgetToolTipConfig = {
   'Race': {
     icon: questionIcon,

--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -513,6 +513,7 @@ export const widgetConfig = [
     width: '100%',
     height: 210,
     tooltip: 'Switch displays between pie and bar charts',
+    countType: 'discrete',
   },
   {
     type: 'bar',
@@ -522,6 +523,7 @@ export const widgetConfig = [
     width: '100%',
     height: 210,
     tooltip: 'Switch displays between pie and bar charts',
+    countType: 'discrete',
   },
   {
     type: 'donut',
@@ -531,6 +533,7 @@ export const widgetConfig = [
     width: '100%',
     height: 210,
     tooltip: 'Switch displays between pie and bar charts',
+    countType: 'discrete',
   },
   {
     type: 'donut',
@@ -540,6 +543,7 @@ export const widgetConfig = [
     width: '100%',
     height: 210,
     tooltip: 'Switch displays between pie and bar charts',
+    countType: 'discrete',
   },
   {
     type: 'bar',
@@ -549,6 +553,7 @@ export const widgetConfig = [
     width: '100%',
     height: 210,
     tooltip: 'Switch displays between pie and bar charts',
+    countType: 'continuous',
   },
   {
     type: 'donut',
@@ -558,5 +563,6 @@ export const widgetConfig = [
     width: '100%',
     height: 210,
     tooltip: 'Switch displays between pie and bar charts',
+    countType: 'discrete',
   },
 ];

--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -2,6 +2,7 @@ import { sortType, InputTypes } from '@bento-core/facet-filter';
 import clearButton from '../assets/icons/Clear_Icon.svg';
 import clearButtonActive from '../assets/icons/Clear_Icon_Active.svg';
 import clearButtonActiveHover from '../assets/icons/Clear_Icon_White.svg';
+import questionIcon from '../assets/icons/Question_Icon.svg';
 
 const DEMOGRAPHICS = 'Demographics';
 const DIAGNOSIS = 'Diagnosis';
@@ -566,3 +567,54 @@ export const widgetConfig = [
     countType: 'discrete',
   },
 ];
+
+export const widgetToolTipConfig = {
+  'Race': {
+    icon: questionIcon,
+    alt: 'race tooltip question mark icon',
+    arrow: true,
+    maxWidth: '230px',
+    clsName: 'widgetTotalTooltipIcon',
+    plural: 'races',
+  },
+  'Sex at Birth': {
+    icon: questionIcon,
+    alt: 'sex tooltip question mark icon',
+    arrow: true,
+    maxWidth: '230px',
+    clsName: 'widgetTotalTooltipIcon',
+    plural: 'sexes',
+  },
+  'Diagnosis': {
+    icon: questionIcon,
+    alt: 'diagnosis tooltip question mark icon',
+    arrow: true,
+    maxWidth: '230px',
+    clsName: 'widgetTotalTooltipIcon',
+    plural: 'diagnoses',
+  },
+  'Anatomic Site': {
+    icon: questionIcon,
+    alt: 'anatomic site tooltip question mark icon',
+    arrow: true,
+    maxWidth: '230px',
+    clsName: 'widgetTotalTooltipIcon',
+    plural: 'anatomic sites',
+  },
+  'Age at Diagnosis (years)': {
+    icon: questionIcon,
+    alt: 'age at diagnosis tooltip question mark icon',
+    arrow: true,
+    maxWidth: '230px',
+    clsName: 'widgetTotalTooltipIcon',
+    plural: 'age groups',
+  },
+  'Treatment Type': {
+    icon: questionIcon,
+    alt: 'treatment type tooltip question mark icon',
+    arrow: true,
+    maxWidth: '230px',
+    clsName: 'widgetTotalTooltipIcon',
+    plural: 'treatment types',
+  },
+};

--- a/src/components/ToolTipIcon/ToolTipIconView.js
+++ b/src/components/ToolTipIcon/ToolTipIconView.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import ToolTip from '@bento-core/tool-tip';
+
+const ToolTipIconView = (props) => {
+  const {
+    tooltipConfig,
+    classes,
+  } = props;
+
+  const {
+    icon,
+    alt,
+    arrow = false,
+    maxWidth,
+    title,
+    placement,
+    clsName,
+  } = tooltipConfig;
+  return (
+    <ToolTip
+      title={title|| 'add'}
+      arrow={arrow}
+      maxWidth={maxWidth || '230px'}
+      placement={placement || 'top-end'}
+      classes={{
+        tooltip: classes.customTooltip,
+        arrow: classes.customArrow,
+      }}
+    >
+      {icon && (<img src={icon} alt={alt} className={clsName} />)}
+    </ToolTip>
+  );
+};
+
+export default ToolTipIconView;

--- a/src/pages/inventory/widget/WidgetStyle.js
+++ b/src/pages/inventory/widget/WidgetStyle.js
@@ -97,6 +97,10 @@ const styles = (theme) => ({
   statsBar: {
     position: 'fixed',
   },
+  widgetTotalTooltipIcon: {
+    width: '10px',
+    transform: 'translateY(-5px)',
+  },
 });
 
 export default styles;

--- a/src/pages/inventory/widget/WidgetView.js
+++ b/src/pages/inventory/widget/WidgetView.js
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from "react";
 import { Button, Collapse, Grid, Switch, withStyles } from "@material-ui/core";
 import ToolTip from "@bento-core/tool-tip";
 import { WidgetGenerator } from "@bento-core/widgets";
-import { widgetConfig, widgetToolTipConfig } from "../../../bento/dashTemplate";
+import { widgetConfig, widgetToolTipConfig, WIDGET_DATASET_LIMIT } from "../../../bento/dashTemplate";
 import colors from "../../../utils/colors";
 import ToolTipIconView from "../../../components/ToolTipIcon/ToolTipIconView";
 import { Typography } from "../../../components/Wrappers/Wrappers";
@@ -18,7 +18,6 @@ const CustomCollapse = withStyles({
 
 const WidgetView = ({ classes, data, theme }) => {
   const displayWidgets = formatWidgetData(data, widgetConfig);
-  const DATASET_LIMIT = 20;
   const [widgetTypes, setWidgetTypes] = useState(
     widgetConfig.map((widget) => {
       return widget.type;
@@ -81,12 +80,12 @@ const WidgetView = ({ classes, data, theme }) => {
             if (widget.countType === "discrete") {
               dataset = dataset.sort((a, b) => b.subjects - a.subjects);
             }
-            if (datasetLength > DATASET_LIMIT) {
+            if (datasetLength > WIDGET_DATASET_LIMIT) {
               const otherGroup = {
                 group: "Other",
-                subjects: dataset.slice(DATASET_LIMIT).reduce((acc, curr) => acc + curr.subjects, 0),
+                subjects: dataset.slice(WIDGET_DATASET_LIMIT).reduce((acc, curr) => acc + curr.subjects, 0),
               };
-              dataset = dataset.slice(0, DATASET_LIMIT).concat(otherGroup);
+              dataset = dataset.slice(0, WIDGET_DATASET_LIMIT).concat(otherGroup);
             }
             if (
               widgetTypes[index] === "sunburst" &&
@@ -96,7 +95,7 @@ const WidgetView = ({ classes, data, theme }) => {
             }
             const widgetTooltip = widgetToolTipConfig[widget.title];
             const dynamicTooltipConfig = {
-              title: `Showing top ${DATASET_LIMIT} out of ${datasetLength} total ${widgetTooltip ? widgetTooltip.plural : 'items'}`,
+              title: `Showing top ${WIDGET_DATASET_LIMIT} out of ${datasetLength} total ${widgetTooltip ? widgetTooltip.plural : 'items'}`,
               clsName: classes.widgetTotalTooltipIcon
             };
             return (
@@ -123,9 +122,9 @@ const WidgetView = ({ classes, data, theme }) => {
                           className={classes.widgetTitle}
                         >
                           {widget.title}
-                          {datasetLength > DATASET_LIMIT && <ToolTipIconView
+                          {datasetLength > WIDGET_DATASET_LIMIT && <ToolTipIconView
                             section={widget.title}
-                            tooltipConfig={Object.assign({}, widgetTooltip, dynamicTooltipConfig)}
+                            tooltipConfig={{...widgetTooltip, ...dynamicTooltipConfig}}
                             classes={classes}
                           />}
                         </Typography>

--- a/src/pages/inventory/widget/WidgetView.js
+++ b/src/pages/inventory/widget/WidgetView.js
@@ -74,6 +74,16 @@ const WidgetView = ({ classes, data, theme }) => {
             if (!dataset || dataset.length === 0) {
               return <></>;
             }
+            if (widget.countType === "discrete") {
+              dataset = dataset.sort((a, b) => b.subjects - a.subjects);
+            }
+            if (dataset.length > 20) {
+              const otherGroup = {
+                group: "Other",
+                subjects: dataset.slice(20).reduce((acc, curr) => acc + curr.subjects, 0),
+              };
+              dataset = dataset.slice(0, 20).concat(otherGroup);
+            }
             if (
               widgetTypes[index] === "sunburst" &&
               (!dataset.children || !dataset.children.length)

--- a/src/pages/inventory/widget/WidgetView.js
+++ b/src/pages/inventory/widget/WidgetView.js
@@ -2,8 +2,9 @@ import React, { useCallback, useState } from "react";
 import { Button, Collapse, Grid, Switch, withStyles } from "@material-ui/core";
 import ToolTip from "@bento-core/tool-tip";
 import { WidgetGenerator } from "@bento-core/widgets";
-import { widgetConfig } from "../../../bento/dashTemplate";
+import { widgetConfig, widgetToolTipConfig } from "../../../bento/dashTemplate";
 import colors from "../../../utils/colors";
+import ToolTipIconView from "../../../components/ToolTipIcon/ToolTipIconView";
 import { Typography } from "../../../components/Wrappers/Wrappers";
 import { formatWidgetData } from "./WidgetUtils";
 import WidgetThemeProvider from "./WidgetTheme";
@@ -17,6 +18,7 @@ const CustomCollapse = withStyles({
 
 const WidgetView = ({ classes, data, theme }) => {
   const displayWidgets = formatWidgetData(data, widgetConfig);
+  const DATASET_LIMIT = 20;
   const [widgetTypes, setWidgetTypes] = useState(
     widgetConfig.map((widget) => {
       return widget.type;
@@ -71,18 +73,20 @@ const WidgetView = ({ classes, data, theme }) => {
               };
             });
             dataset = newDataset;
-            if (!dataset || dataset.length === 0) {
+            const datasetLength = dataset.length;
+            
+            if (!dataset || datasetLength === 0) {
               return <></>;
             }
             if (widget.countType === "discrete") {
               dataset = dataset.sort((a, b) => b.subjects - a.subjects);
             }
-            if (dataset.length > 20) {
+            if (datasetLength > DATASET_LIMIT) {
               const otherGroup = {
                 group: "Other",
-                subjects: dataset.slice(20).reduce((acc, curr) => acc + curr.subjects, 0),
+                subjects: dataset.slice(DATASET_LIMIT).reduce((acc, curr) => acc + curr.subjects, 0),
               };
-              dataset = dataset.slice(0, 20).concat(otherGroup);
+              dataset = dataset.slice(0, DATASET_LIMIT).concat(otherGroup);
             }
             if (
               widgetTypes[index] === "sunburst" &&
@@ -90,6 +94,10 @@ const WidgetView = ({ classes, data, theme }) => {
             ) {
               return <></>;
             }
+            const dynamicTooltipConfig = {
+              title: `Showing top ${DATASET_LIMIT} out of ${datasetLength} total ${widgetToolTipConfig[widget.title].plural}`,
+              clsName: classes.widgetTotalTooltipIcon
+            };
             return (
               <Grid key={index} item lg={4} md={6} sm={12} xs={12}>
                 <WidgetThemeProvider>
@@ -114,6 +122,11 @@ const WidgetView = ({ classes, data, theme }) => {
                           className={classes.widgetTitle}
                         >
                           {widget.title}
+                          {datasetLength > 20 && <ToolTipIconView
+                            section={widget.title}
+                            tooltipConfig={Object.assign({}, widgetToolTipConfig[widget.title], dynamicTooltipConfig)}
+                            classes={classes}
+                          />}
                         </Typography>
                         <div>{
                         //TODO: Add download button and style this parent div

--- a/src/pages/inventory/widget/WidgetView.js
+++ b/src/pages/inventory/widget/WidgetView.js
@@ -73,11 +73,11 @@ const WidgetView = ({ classes, data, theme }) => {
               };
             });
             dataset = newDataset;
-            const datasetLength = dataset.length;
             
-            if (!dataset || datasetLength === 0) {
+            if (!dataset || dataset.length === 0) {
               return <></>;
             }
+            const datasetLength = dataset.length;
             if (widget.countType === "discrete") {
               dataset = dataset.sort((a, b) => b.subjects - a.subjects);
             }
@@ -94,8 +94,9 @@ const WidgetView = ({ classes, data, theme }) => {
             ) {
               return <></>;
             }
+            const widgetTooltip = widgetToolTipConfig[widget.title];
             const dynamicTooltipConfig = {
-              title: `Showing top ${DATASET_LIMIT} out of ${datasetLength} total ${widgetToolTipConfig[widget.title].plural}`,
+              title: `Showing top ${DATASET_LIMIT} out of ${datasetLength} total ${widgetTooltip ? widgetTooltip.plural : 'items'}`,
               clsName: classes.widgetTotalTooltipIcon
             };
             return (
@@ -122,9 +123,9 @@ const WidgetView = ({ classes, data, theme }) => {
                           className={classes.widgetTitle}
                         >
                           {widget.title}
-                          {datasetLength > 20 && <ToolTipIconView
+                          {datasetLength > DATASET_LIMIT && <ToolTipIconView
                             section={widget.title}
-                            tooltipConfig={Object.assign({}, widgetToolTipConfig[widget.title], dynamicTooltipConfig)}
+                            tooltipConfig={Object.assign({}, widgetTooltip, dynamicTooltipConfig)}
                             classes={classes}
                           />}
                         </Typography>


### PR DESCRIPTION
[C3DC-1598](https://tracker.nci.nih.gov/browse/C3DC-1598)

- Widgets now show top 20 results + other if there are more than 20 results
- Widgets are considered continuous or discrete for the purposes of sorting
- Widgets are also sorted by largest to smallest if discrete, with other at the end.
- Tooltips are added when data is truncated by the top 20 limit.
- Added config for Tooltips
- Added new TooltipIcon component as seen in https://github.com/CBIIT/bento-frontend/blob/6f96732e7dfc00eea970bf1f5825b637e7522762/packages/paginated-table/src/wrapper/components/TooltipView.js 