### PR TITLE
C3DC-1673 - Added aria label to widget toggle switch 

### DIFF
--- a/src/pages/inventory/widget/WidgetView.js
+++ b/src/pages/inventory/widget/WidgetView.js
@@ -140,6 +140,7 @@ const WidgetView = ({ classes, data, theme }) => {
                               <Switch
                                 onChange={() => toggleWidgetType(index)}
                                 checked={widgetTypes[index] === "bar"}
+                                inputProps={{ 'aria-label': `Toggle chart type for ${widget.title}` }}
                               />
                             </div>
                           </ToolTip>


### PR DESCRIPTION
Using MUI's documentation for the Switch component, the inputProp prop is used to pass props to the input field  of the toggle switch. Utilizing this, we can add an aria label.

[C3DC-1673](https://tracker.nci.nih.gov/browse/C3DC-1673)