### PR TITLE
C3DC-1674 fixed widget title styling to match design

### DIFF
--- a/src/pages/inventory/widget/WidgetStyle.js
+++ b/src/pages/inventory/widget/WidgetStyle.js
@@ -25,7 +25,12 @@ const styles = (theme) => ({
     background: theme.palette.widgetBackground.main,
   },
   widgetTitle: {
-    fontSize: '20px',
+    fontSize: '19px !important',
+    fontWeight: '500',
+    fontFamily: 'Lato',
+    color: theme.palette.text.primary,
+    textAlign: "start",
+    width: "100%",
   },
   contentShift: {
     width: `calc(100vw - ${theme.custom.drawerWidth})`,
@@ -109,7 +114,7 @@ const styles = (theme) => ({
   },
   widgetTotalTooltipIcon: {
     width: '10px',
-    transform: 'translateY(-5px)',
+    transform: 'translateY(-10px) translateX(1px)',
   },
 });
 

--- a/src/pages/inventory/widget/WidgetView.js
+++ b/src/pages/inventory/widget/WidgetView.js
@@ -108,18 +108,11 @@ const WidgetView = ({ classes, data, theme }) => {
                         style={{
                           display: "flex",
                           width: "100%",
-                          flex:1
+                          flex:1,
+                          alignItems: "center"
                         }}
                       >
                         <Typography
-                          size="md"
-                          weight="normal"
-                          family="Nunito"
-                          style={{
-                            textAlign: "start",
-                            width: "100%",
-                          }}
-                          color="lochmara"
                           className={classes.widgetTitle}
                         >
                           {widget.title}


### PR DESCRIPTION
The fontsize was overwritten so we have to prioritize the styling we have defined in the style sheet.

Added some supporting styles to the tooltipIcon (due to new size) and centering the switch icon if text ends up on multiple lines as well as matching the rest of the design from figma

[C3DC-1674](https://tracker.nci.nih.gov/browse/C3DC-1674)