### PR TITLE
C3DC-1708

### DIFF
--- a/src/bento/cohortModalData.js
+++ b/src/bento/cohortModalData.js
@@ -6,7 +6,7 @@
 
 // Action Button Configuration
 export const CCDI_HUB_BASE_URL = "https://ccdi.cancer.gov/explore?import_from=";
-export const CCDI_INTEROP_SERVICE_URL = "https://ccdi.cancer.gov/api/interoperation/graphql";
+export const CCDI_INTEROP_SERVICE_URL = "https://ccdi-dev.cancer.gov/api/interoperation/graphql";
 
 // Deletion Types Configuration
 export const deletionTypes = {

--- a/src/bento/cohortModalData.js
+++ b/src/bento/cohortModalData.js
@@ -6,6 +6,7 @@
 
 // Action Button Configuration
 export const CCDI_HUB_BASE_URL = "https://ccdi.cancer.gov/explore?import_from=";
+export const CCDI_INTEROP_SERVICE_URL = "https://ccdi.cancer.gov/api/interoperation/graphql";
 
 // Deletion Types Configuration
 export const deletionTypes = {
@@ -36,6 +37,5 @@ export const TOOLTIP_MESSAGES = {
     removeAllCohorts: "Remove all Cohorts",
     exploreCCDIHub: {
         mainText: "Clicking this button will create a url and open a new tab showing the CCDI Hub Explore page with filtered facets based on the user's selected cohort.",
-        smallCohortText: "Proceed with direct export within C3DC.",
     }
 };

--- a/src/bento/cohortModalData.js
+++ b/src/bento/cohortModalData.js
@@ -5,7 +5,6 @@
  */
 
 // Action Button Configuration
-export const COHORT_SIZE_LIMIT = 600;
 export const CCDI_HUB_BASE_URL = "https://ccdi.cancer.gov/explore?import_from=";
 
 // Deletion Types Configuration
@@ -38,14 +37,5 @@ export const TOOLTIP_MESSAGES = {
     exploreCCDIHub: {
         mainText: "Clicking this button will create a url and open a new tab showing the CCDI Hub Explore page with filtered facets based on the user's selected cohort.",
         smallCohortText: "Proceed with direct export within C3DC.",
-        largeCohortText: "Download the manifest and upload it manually to the",
-        ccdiHubUrl: "https://ccdi.cancer.gov/explore",
-        ccdiHubText: "CCDI Hub",
-        followingStepsText: "by following these steps:",
-        steps: [
-            "Choose the Explore page from the menu.",
-            "In the Facets side panel, open the Demographic facet.",
-            'Click on "Upload Participants Set."'
-        ]
     }
 };

--- a/src/bento/cohortModalData.js
+++ b/src/bento/cohortModalData.js
@@ -6,8 +6,7 @@
 
 // Action Button Configuration
 export const COHORT_SIZE_LIMIT = 600;
-export const CCDI_HUB_BASE_URL = "https://ccdi.cancer.gov/explore?p_id=";
-export const DBGAP_PARAM = "&dbgap_accession=";
+export const CCDI_HUB_BASE_URL = "https://ccdi.cancer.gov/explore?import_from=";
 
 // Deletion Types Configuration
 export const deletionTypes = {

--- a/src/components/CohortModal/components/CohortDetails/CohortDetails.js
+++ b/src/components/CohortModal/components/CohortDetails/CohortDetails.js
@@ -3,7 +3,7 @@ import { withStyles } from '@material-ui/core';
 import { CohortStateContext } from '../../../../components/CohortSelectorState/CohortStateContext.js';
 import { onMutateSingleCohort } from '../../../../components/CohortSelectorState/store/action.js';
 import { CohortModalContext } from '../../CohortModalContext.js';
-import { getManifestPayload } from '../../utils.js';
+import { getManifestPayload, truncateSignedUrl } from '../../utils.js';
 import CohortMetadata from './components/CohortMetadata';
 import ParticipantList from './components/ParticipantList';
 import ActionButtons from './components/ActionButtons';
@@ -101,7 +101,13 @@ const CohortDetails = (props) => {
                 throw new Error((result.errors[0] && result.errors[0].message) || 'GraphQL error occurred');
             }
 
-            setUrlData(result.data);
+            // Process the URL data to truncate signed URL parameters
+            const processedData = {
+                ...result.data,
+                storeManifest: result.data.storeManifest ? truncateSignedUrl(result.data.storeManifest) : result.data.storeManifest
+            };
+
+            setUrlData(processedData);
             setUrlGenerationFailed(false);
         } catch (error) {
             console.error('Error generating CCDI Hub URL:', error);

--- a/src/components/CohortModal/components/CohortDetails/CohortDetails.js
+++ b/src/components/CohortModal/components/CohortDetails/CohortDetails.js
@@ -77,7 +77,7 @@ const CohortDetails = (props) => {
                 }
             `;
             
-            const response = await fetch('https://ccdi-stage.cancer.gov/api/interoperation/graphql', {
+            const response = await fetch('https://ccdi-dev.cancer.gov/api/interoperation/graphql', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/src/components/CohortModal/components/CohortDetails/CohortDetails.js
+++ b/src/components/CohortModal/components/CohortDetails/CohortDetails.js
@@ -99,7 +99,9 @@ const CohortDetails = (props) => {
             const result = await response.json();
             
             if (result.errors) {
-                throw new Error((result.errors[0] && result.errors[0].message) || 'GraphQL error occurred');
+                const errorMessage = (result.errors[0] && result.errors[0].message) || 'Unknown GraphQL error';
+                const participantCount = payload ? payload.length : 0;
+                throw new Error(`CCDI Interop Service Error: ${errorMessage} (Processing ${participantCount} study groups)`);
             }
 
             // Process the URL data to truncate signed URL parameters

--- a/src/components/CohortModal/components/CohortDetails/CohortDetails.js
+++ b/src/components/CohortModal/components/CohortDetails/CohortDetails.js
@@ -4,6 +4,7 @@ import { CohortStateContext } from '../../../../components/CohortSelectorState/C
 import { onMutateSingleCohort } from '../../../../components/CohortSelectorState/store/action.js';
 import { CohortModalContext } from '../../CohortModalContext.js';
 import { getManifestPayload, truncateSignedUrl } from '../../utils.js';
+import { CCDI_INTEROP_SERVICE_URL } from '../../../../bento/cohortModalData.js';
 import CohortMetadata from './components/CohortMetadata';
 import ParticipantList from './components/ParticipantList';
 import ActionButtons from './components/ActionButtons';
@@ -77,7 +78,7 @@ const CohortDetails = (props) => {
                 }
             `;
             
-            const response = await fetch('https://ccdi-dev.cancer.gov/api/interoperation/graphql', {
+            const response = await fetch(CCDI_INTEROP_SERVICE_URL, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/src/components/CohortModal/components/CohortDetails/components/ActionButtons.js
+++ b/src/components/CohortModal/components/CohortDetails/components/ActionButtons.js
@@ -110,11 +110,6 @@ const ActionButtons = (props) => {
     const exploreCCDIHubTooltip = useMemo(() => (
         <p style={{ fontFamily: "Poppins", zIndex: 10000, fontWeight: 400, fontSize: 13, margin: 0 }}>
             {TOOLTIP_MESSAGES.exploreCCDIHub.mainText}
-            <br/>
-            <Gap/>
-            <b>All cohorts:</b>
-            <br/> 
-            {TOOLTIP_MESSAGES.exploreCCDIHub.smallCohortText}
         </p>
     ), []);
 

--- a/src/components/CohortModal/components/CohortDetails/components/ActionButtons.js
+++ b/src/components/CohortModal/components/CohortDetails/components/ActionButtons.js
@@ -3,13 +3,12 @@ import { withStyles, Button } from '@material-ui/core';
 import { useNavigate } from 'react-router-dom';
 import ExpandMoreIcon from '../../../../../assets/icons/Expand_More_Icon.svg';
 import Linkout from "../../../../../assets/about/Export_Icon_White.svg";
-import LinkoutBlue from "../../../../../assets/about/Export_Icon.svg";
 import ToolTip from '@bento-core/tool-tip';
 import { GET_COHORT_MANIFEST_QUERY, GET_COHORT_METADATA_QUERY } from '../../../../../bento/dashboardTabData.js';
 import client from '../../../../../utils/graphqlClient.js';
 import { arrayToCSVDownload, objectToJsonDownload } from '../../../utils.js';
 import { CohortModalContext } from '../../../CohortModalContext.js';
-import { COHORT_SIZE_LIMIT, CCDI_HUB_BASE_URL, TOOLTIP_MESSAGES } from '../../../../../bento/cohortModalData.js';
+import { CCDI_HUB_BASE_URL, TOOLTIP_MESSAGES } from '../../../../../bento/cohortModalData.js';
 
 const ActionButtons = (props) => {
     const { 
@@ -113,33 +112,9 @@ const ActionButtons = (props) => {
             {TOOLTIP_MESSAGES.exploreCCDIHub.mainText}
             <br/>
             <Gap/>
-            <b>If cohort size &le; {COHORT_SIZE_LIMIT}:</b>
+            <b>All cohorts:</b>
             <br/> 
             {TOOLTIP_MESSAGES.exploreCCDIHub.smallCohortText}
-            <br/>
-            <Gap/>
-            <b>If cohort size &gt; {COHORT_SIZE_LIMIT}:</b><br/> 
-            {TOOLTIP_MESSAGES.exploreCCDIHub.largeCohortText}&nbsp;
-            <a style={{zIndex: 10000}} target='_blank' href={TOOLTIP_MESSAGES.exploreCCDIHub.ccdiHubUrl} rel="noreferrer">
-                {TOOLTIP_MESSAGES.exploreCCDIHub.ccdiHubText}
-                <img 
-                    src={LinkoutBlue} 
-                    width={14} 
-                    height={14} 
-                    style={{
-                        padding: "4px 0px 0px 2px", 
-                        bottom: 0, 
-                        position: 'relative'
-                    }} 
-                    alt="Linkout Icon" 
-                /> 
-            </a>
-            &nbsp;{TOOLTIP_MESSAGES.exploreCCDIHub.followingStepsText}
-            <ol>
-                {TOOLTIP_MESSAGES.exploreCCDIHub.steps.map((step, index) => (
-                    <li key={index}>{step}</li>
-                ))}
-            </ol>
         </p>
     ), []);
 
@@ -175,18 +150,16 @@ const ActionButtons = (props) => {
     }, []);
 
     const handleCCDIHubClick = useCallback(() => {
-        if (localCohort.participants.length <= COHORT_SIZE_LIMIT) {
-            if (isGeneratingUrl) {
-                showAlert('info', 'Please wait while we prepare the CCDI Hub link...');
-                return;
-            }
-            if (urlGenerationFailed) {
-                showAlert('error', 'CCDI Hub URL generation failed. Please try refreshing the page.');
-                return;
-            }
-            generateCCDIHub_url();
+        if (isGeneratingUrl) {
+            showAlert('info', 'Please wait while we prepare the CCDI Hub link...');
+            return;
         }
-    }, [localCohort.participants.length, isGeneratingUrl, urlGenerationFailed, generateCCDIHub_url, showAlert]);
+        if (urlGenerationFailed) {
+            showAlert('error', 'CCDI Hub URL generation failed. Please try refreshing the page.');
+            return;
+        }
+        generateCCDIHub_url();
+    }, [isGeneratingUrl, urlGenerationFailed, generateCCDIHub_url, showAlert]);
 
     return (
         <div className={classes.actionButtonsContainer}>
@@ -252,12 +225,10 @@ const ActionButtons = (props) => {
             >
                 <Button 
                     variant="contained"
-                    className={localCohort.participants.length > COHORT_SIZE_LIMIT || isGeneratingUrl || urlGenerationFailed ? classes.exploreButtonFaded : classes.exploreButton}
+                    className={isGeneratingUrl || urlGenerationFailed ? classes.exploreButtonFaded : classes.exploreButton}
                     onClick={handleCCDIHubClick}
-                    disabled={localCohort.participants.length > COHORT_SIZE_LIMIT || isGeneratingUrl || urlGenerationFailed}
-                    aria-label={localCohort.participants.length > COHORT_SIZE_LIMIT ? 
-                        `Explore in CCDI Hub (disabled - cohort size ${localCohort.participants.length} exceeds limit of ${COHORT_SIZE_LIMIT})` : 
-                        urlGenerationFailed ? 'CCDI Hub URL generation failed' :
+                    disabled={isGeneratingUrl || urlGenerationFailed}
+                    aria-label={urlGenerationFailed ? 'CCDI Hub URL generation failed' :
                         isGeneratingUrl ? 'Preparing CCDI Hub link...' : 'Open cohort in CCDI Hub in new tab'
                     }
                 >

--- a/src/components/CohortModal/utils.js
+++ b/src/components/CohortModal/utils.js
@@ -126,6 +126,13 @@ export const getManifestPayload = (participants) => {
   // Group participants by study_id (dbgap_accession)
   const studyGroups = participants.reduce((acc, participant) => {
     const studyId = participant.dbgap_accession;
+    
+    // Skip participants with missing or invalid dbgap_accession
+    if (studyId === undefined || studyId === null || studyId === '') {
+      console.warn('Participant missing dbgap_accession:', participant.participant_id || 'Unknown participant');
+      return acc;
+    }
+    
     if (!acc[studyId]) {
       acc[studyId] = {
         study_id: studyId,

--- a/src/components/CohortModal/utils.js
+++ b/src/components/CohortModal/utils.js
@@ -117,3 +117,26 @@ export const objectToJsonDownload = (obj, cohortID) => {
     return JSON.stringify(filteredObj1) !== JSON.stringify(filteredObj2);
   };
 
+// Helper function to create manifest payload for interop service
+export const getManifestPayload = (participants) => {
+  if (!participants || !Array.isArray(participants)) {
+    return [];
+  }
+  
+  // Group participants by study_id (dbgap_accession)
+  const studyGroups = participants.reduce((acc, participant) => {
+    const studyId = participant.dbgap_accession;
+    if (!acc[studyId]) {
+      acc[studyId] = {
+        study_id: studyId,
+        participant_id: []
+      };
+    }
+    acc[studyId].participant_id.push(participant.participant_id);
+    return acc;
+  }, {});
+  
+  // Convert to array format
+  return Object.values(studyGroups);
+};
+

--- a/src/components/CohortModal/utils.js
+++ b/src/components/CohortModal/utils.js
@@ -140,3 +140,15 @@ export const getManifestPayload = (participants) => {
   return Object.values(studyGroups);
 };
 
+// Helper function to truncate signed CloudFront URLs at .json
+export const truncateSignedUrl = (url) => {
+  if (!url || typeof url !== 'string') return url;
+  
+  const jsonIndex = url.indexOf('.json');
+  if (jsonIndex !== -1) {
+    return url.substring(0, jsonIndex + 5); // +5 to include ".json"
+  }
+  
+  return url; // Return original if no .json found
+};
+


### PR DESCRIPTION
[C3DC-1708](https://tracker.nci.nih.gov/browse/C3DC-1708)

# Don't merge until August 11 - Waiting on CCDI's Prod endpoints to be ready

- When opening the cohort modal, the current cohort will send a call to the interop service and and receive an unsigned url containing a json file of all the participants. This will be used by the CCDI hub to import the participants.
- When opening the cohort, there will be a brief pause before the export button works - this is waiting on the interop service response, if the response fails, then there will be an alert
- We have removed the limit from the tooltip and logic regarding the limit since the limit is now gone with this interop service integration.
- As suggested by Wei, we also truncated the URL to only include the file. Discarding any extra params
