### PR TITLE
added elipsis limit to name field

### DIFF
--- a/src/components/CohortModal/components/CohortDetails/components/CohortMetadata.js
+++ b/src/components/CohortModal/components/CohortDetails/components/CohortMetadata.js
@@ -194,6 +194,9 @@ const styles = () => ({
     },
     cohortName: {
         width: '250px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
     },
     editingCohortTitle: {
         fontFamily: 'Poppins',
@@ -229,6 +232,9 @@ const styles = () => ({
         },
         boxSizing: 'border-box',
         border: 'none',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
     },
     editIcon: {
         height: '13px',


### PR DESCRIPTION
[C3DC-1737](https://tracker.nci.nih.gov/browse/C3DC-1737)

Title field of cohort now will be truncatec with an elipsis if it goes past the border box