### PR TITLE
Removed all references of "numberOfReferenceFiles" query from C3DC Frontend.

### DIFF
--- a/src/bento/globalStatsData.js
+++ b/src/bento/globalStatsData.js
@@ -84,7 +84,6 @@ export const GET_GLOBAL_STATS_DATA_QUERY = gql`
 {
   numberOfDiseases,
   numberOfParticipants,
-  numberOfReferenceFiles,
   numberOfStudies,
   numberOfSurvivals
   }

--- a/src/bento/landingPageData.js
+++ b/src/bento/landingPageData.js
@@ -101,7 +101,6 @@ export const landingPageData = {
 export const GLOBAL_STATS_BAR_QUERY = gql`{
   numberOfDiseases,
   numberOfParticipants,
-  numberOfReferenceFiles,
   numberOfStudies,
   numberOfSurvivals
   }


### PR DESCRIPTION
FE was showing the following error on pages such as Home, Studies, and Cohort Analyzer:

> "An error has occurred in loading stats component: ApolloError: Validation error (FieldUndefined@[numberOfReferenceFiles]): Field 'numberOfReferenceFiles' in type 'QueryType' is undefined."

Thanks to @Senait7-ux for pointing out the issue and to @JoonLeeNIH for helping track it down. I was able to resolve it, and this PR contains the fix.