### PR TITLE
hotfix update to prevent crash with 7 tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@bento-core/paginated-table": "^1.0.0-c3dc.35",
         "@bento-core/query-bar": "^1.0.0-c3dc.7",
         "@bento-core/stats-bar": "1.0.1-ccdihub.2",
-        "@bento-core/tab": "^1.0.0-c3dc.2",
+        "@bento-core/tab": "^1.0.0-c3dc.3",
         "@bento-core/table": "^1.0.0-c3dc.29",
         "@bento-core/tool-tip": "^1.0.0-c3dc.0",
         "@bento-core/util": "^1.0.0-ccdihub.0",
@@ -1564,9 +1564,9 @@
       }
     },
     "node_modules/@bento-core/tab": {
-      "version": "1.0.0-c3dc.2",
-      "resolved": "https://registry.npmjs.org/@bento-core/tab/-/tab-1.0.0-c3dc.2.tgz",
-      "integrity": "sha512-1Z1j3AGoCpMO7Wmz2VVa+4kSLliXeH9569VbIppwgUXfx9sOUNFtHBcciwbpCBe5aOAhfvcJv9QRozKufHo+qw==",
+      "version": "1.0.0-c3dc.3",
+      "resolved": "https://registry.npmjs.org/@bento-core/tab/-/tab-1.0.0-c3dc.3.tgz",
+      "integrity": "sha512-9yP7gm6JKcLlzSq8ATuvI7t65OiD0p4vFY3zgTROb0pOQgK+a80FNk1pB+fRnmyoNdLaGzINNsgB22+OSYfClw==",
       "peerDependencies": {
         "@bento-core/tool-tip": "1.0.0-c3dc.0",
         "@material-ui/core": "^4.12.4",
@@ -23262,9 +23262,9 @@
       "integrity": "sha512-lgzMTtdGgVxImMn1lCZWUavtqlxYYEBV1bCy7pZnChL/LRyBXrZuGC2/PT4pxAZrEWiYrOuG8WY5WQu+t+ke/A=="
     },
     "@bento-core/tab": {
-      "version": "1.0.0-c3dc.2",
-      "resolved": "https://registry.npmjs.org/@bento-core/tab/-/tab-1.0.0-c3dc.2.tgz",
-      "integrity": "sha512-1Z1j3AGoCpMO7Wmz2VVa+4kSLliXeH9569VbIppwgUXfx9sOUNFtHBcciwbpCBe5aOAhfvcJv9QRozKufHo+qw=="
+      "version": "1.0.0-c3dc.3",
+      "resolved": "https://registry.npmjs.org/@bento-core/tab/-/tab-1.0.0-c3dc.3.tgz",
+      "integrity": "sha512-9yP7gm6JKcLlzSq8ATuvI7t65OiD0p4vFY3zgTROb0pOQgK+a80FNk1pB+fRnmyoNdLaGzINNsgB22+OSYfClw=="
     },
     "@bento-core/table": {
       "version": "1.0.0-c3dc.29",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@bento-core/paginated-table": "^1.0.0-c3dc.35",
     "@bento-core/query-bar": "^1.0.0-c3dc.7",
     "@bento-core/stats-bar": "1.0.1-ccdihub.2",
-    "@bento-core/tab": "^1.0.0-c3dc.2",
+    "@bento-core/tab": "^1.0.0-c3dc.3",
     "@bento-core/table": "^1.0.0-c3dc.29",
     "@bento-core/tool-tip": "^1.0.0-c3dc.0",
     "@bento-core/util": "^1.0.0-ccdihub.0",


### PR DESCRIPTION
when there are 7 tabs and you select the 7th tab and go to the lowest width to the highest width breakpoints, it causes a crash. This is due to a null reference in the library, we've since added a null check now