### PR TITLE
C3DC-1851 added dbgap accession to genetic analysis for cohort creation

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -2256,7 +2256,7 @@ export const tabContainers = [
     fileCount: 'geneticAnalysisFileCount',
     toolTipText: 'Count of Genetic Analysis Record',
     dataKey: "id",
-    hiddenDataKeys: ['participant', 'participant_pk'],
+    hiddenDataKeys: ['participant', 'participant_pk', 'dbgap_accession'],
     tableID: 'genetic_analysis_tab_table',
     extendedViewConfig: {
       pagination: true,


### PR DESCRIPTION
[C3DC-1851](https://tracker.nci.nih.gov/browse/C3DC-1851)

This issue was a result of missing the dbgap_accession being passed down into the cohort redux. We needed to add it in the hidden data keys (which are passed down when using the check box) it has been resolved. 