### PR TITLE
C3DC-1849 update download list behavior and table list rendering

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -1688,6 +1688,7 @@ export const tabContainers = [
         display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
+        cellType: cellTypes.CUSTOM_ELEM,
       },
       {
         dataField: 'sex_at_birth',
@@ -1783,6 +1784,7 @@ export const tabContainers = [
         display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
+        cellType: cellTypes.CUSTOM_ELEM,
       },
       {
         dataField: 'diagnosis_basis',
@@ -1790,6 +1792,7 @@ export const tabContainers = [
         display: true,
         tooltipText: 'sort',
         role: cellTypes.DISPLAY,
+        cellType: cellTypes.CUSTOM_ELEM,
       },
       {
         dataField: 'diagnosis_comment',

--- a/src/components/CohortModal/utils.js
+++ b/src/components/CohortModal/utils.js
@@ -47,6 +47,33 @@ function cleanGraphQLTypenames(obj) {
     return obj; 
   };
 
+  /**
+   * Helper function to format array values for CSV export
+   * Handles GraphQL response arrays (like race, diagnosis, etc.) by flattening them
+   * into single CSV cell values using semicolon separation.
+   *
+   * @param {*} value - The value to format (may be array or primitive)
+   * @returns {string} - Formatted value safe for CSV export
+   *
+   * Example: ['White', 'Asian'] -> 'White; Asian'
+   */
+  const formatArrayForCSV = (value) => {
+    if (Array.isArray(value)) {
+      // Join array elements with semicolon separator to avoid comma conflicts in CSV
+      const joinedValue = value.filter(item => item != null && item !== '').join('; ');
+      return joinedValue || '';
+    }
+    return value || '';
+  };
+
+  /**
+   * Downloads cohort data as CSV file with proper handling of array fields.
+   * Automatically flattens array values (like race) into semicolon-separated strings
+   * to prevent CSV parsing issues with multiple columns.
+   *
+   * @param {Array} arr - Array of data objects to export
+   * @param {string} cohortID - Cohort identifier for filename
+   */
   export const arrayToCSVDownload = (arr, cohortID) => {
     const keys = Object.keys(DOWNLOAD_MANIFEST_KEYS);
     const header = keys.join(',');
@@ -60,12 +87,16 @@ function cleanGraphQLTypenames(obj) {
                 } else if (k === 'Sex at Birth') {
                     value = row.participant.sex_at_birth || '';
                 } else if (k === 'Race') {
-                    value = row.participant.race || '';
+                    value = formatArrayForCSV(row.participant.race);
                 }
             }
 
-            if (typeof value === 'string' && (value.includes(',') || value.includes('"'))) {
-                value = `"${value.replace(/"/g, '""')}"`; 
+            // Handle other potential array fields
+            value = formatArrayForCSV(value);
+
+            // Escape CSV special characters
+            if (typeof value === 'string' && (value.includes(',') || value.includes('"') || value.includes('\n'))) {
+                value = `"${value.replace(/"/g, '""')}"`;
             }
 
             return value;
@@ -76,7 +107,7 @@ function cleanGraphQLTypenames(obj) {
 
     const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8' });
     const JsonURL = window.URL.createObjectURL(blob);
-    
+
     let tempLink = document.createElement('a');
     tempLink.setAttribute('href', JsonURL);
     tempLink.setAttribute('download', generateDownloadFileName(true, cohortID));


### PR DESCRIPTION
The download feature was shifting over columns due to list values being separate cells in the table download. We've added an extra util function to keep them as one, separated by a semicolon.

Similarly, the frontend also needed to update rendering certain columns as they as list values. I've reached out to Joon and the following values need to be treated as columns. 

```
race
treatment_agent
diagnosis_classification_system
diagnosis_basis
gene_symbol (have to be careful to remember this one in the future, because it's not a list in the datamodel. We listify it thanks to the observation you shared with the data team)
```