### PR TITLE
C3DC-1852 - download behavior inconsistency fix

### DIFF
--- a/src/bento/cohortModalData.js
+++ b/src/bento/cohortModalData.js
@@ -27,6 +27,8 @@ export const SCROLLBAR_WIDTH = '6px';
 export const IGNORED_FIELDS = ["cohortId"];
 
 // Download Configuration
+export const DEFAULT_QUERY_LIMIT = 60000;
+
 export const DOWNLOAD_MANIFEST_KEYS = {
     'Participant ID': 'participant_id',
     'dbGaP Accession': 'dbgap_accession',

--- a/src/components/CohortModal/components/CohortDetails/components/ActionButtons.js
+++ b/src/components/CohortModal/components/CohortDetails/components/ActionButtons.js
@@ -18,28 +18,27 @@ const ActionButtons = (props) => {
     const { showAlert } = useContext(CohortModalContext);
     
     // Loading states
-    const [isDownloadingManifest, setIsDownloadingManifest] = useState(false);
-    const [isDownloadingMetadata, setIsDownloadingMetadata] = useState(false);
+    const [isDownloading, setIsDownloading] = useState(false);
     const [isExportingToCCDI, setIsExportingToCCDI] = useState(false);
     
     // Download functions (memoized for performance with error handling)
     const handleDownloadManifest = useCallback(async () => {
-        if (isDownloadingManifest) return; // Prevent multiple simultaneous downloads
+        if (isDownloading) return; // Prevent multiple simultaneous downloads
 
         await downloadCohortManifest(localCohort.participants, localCohort.cohortId, {
             showAlert,
-            onLoadingStateChange: setIsDownloadingManifest
+            onLoadingStateChange: setIsDownloading
         });
-    }, [localCohort.participants, localCohort.cohortId, isDownloadingManifest, showAlert]);
+    }, [localCohort.participants, localCohort.cohortId, isDownloading, showAlert]);
 
     const handleDownloadMetadata = useCallback(async () => {
-        if (isDownloadingMetadata) return; // Prevent multiple simultaneous downloads
+        if (isDownloading) return; // Prevent multiple simultaneous downloads
 
         await downloadCohortMetadata(localCohort.participants, localCohort.cohortId, {
             showAlert,
-            onLoadingStateChange: setIsDownloadingMetadata
+            onLoadingStateChange: setIsDownloading
         });
-    }, [localCohort.participants, localCohort.cohortId, isDownloadingMetadata, showAlert]);
+    }, [localCohort.participants, localCohort.cohortId, isDownloading, showAlert]);
     
     // CCDI Hub export function using centralized utility
     const handleExportToCCDIHub = useCallback(async () => {
@@ -117,7 +116,7 @@ const ActionButtons = (props) => {
                     variant="contained"
                     className={showDownloadDropdown ? classes.downloadButtonOpened : classes.downloadButton}
                     onClick={handleDownloadDropdown}
-                    disabled={isDownloadingManifest || isDownloadingMetadata}
+                    disabled={isDownloading}
                     aria-label="Download cohort data - select format"
                 >
                     <div className={classes.downloadButtonText}>

--- a/src/components/CohortModal/utils.js
+++ b/src/components/CohortModal/utils.js
@@ -1,4 +1,6 @@
-import { DOWNLOAD_MANIFEST_KEYS, CCDI_HUB_BASE_URL, CCDI_INTEROP_SERVICE_URL, CCDI_HUB_LEGACY_BASE_URL, CCDI_HUB_DBGAP_PARAM } from '../../bento/cohortModalData';
+import { DOWNLOAD_MANIFEST_KEYS, CCDI_HUB_BASE_URL, CCDI_INTEROP_SERVICE_URL, CCDI_HUB_LEGACY_BASE_URL, CCDI_HUB_DBGAP_PARAM, DEFAULT_QUERY_LIMIT } from '../../bento/cohortModalData';
+import { GET_COHORT_MANIFEST_QUERY, GET_COHORT_METADATA_QUERY } from '../../bento/dashboardTabData';
+import client from '../../utils/graphqlClient';
 
 function generateDownloadFileName(isManifest, cohortID) {
     const date = new Date();
@@ -254,6 +256,63 @@ export const exportToCCDIHub = async (participants, options = {}) => {
       showAlert('error', `Failed to export to CCDI Hub: ${error.message}`);
     }
     return null;
+  } finally {
+    if (onLoadingStateChange) onLoadingStateChange(false);
+  }
+};
+
+// Centralized download functions for cohort data
+export const downloadCohortManifest = async (participants, cohortId, options = {}) => {
+  const { showAlert, onLoadingStateChange } = options;
+
+  try {
+    if (onLoadingStateChange) onLoadingStateChange(true);
+
+    const participantPKs = participants.map(item => item.participant_pk);
+    const { data } = await client.query({
+      query: GET_COHORT_MANIFEST_QUERY,
+      variables: {
+        "participant_pk": participantPKs,
+        "first": DEFAULT_QUERY_LIMIT
+      },
+    });
+
+    arrayToCSVDownload(data['diagnosisOverview'], cohortId);
+    if (showAlert) showAlert('success', 'Manifest CSV downloaded successfully!');
+
+    return data;
+  } catch (error) {
+    console.error('Error downloading cohort manifest:', error);
+    if (showAlert) showAlert('error', 'Failed to download manifest. Please try again.');
+    throw error;
+  } finally {
+    if (onLoadingStateChange) onLoadingStateChange(false);
+  }
+};
+
+export const downloadCohortMetadata = async (participants, cohortId, options = {}) => {
+  const { showAlert, onLoadingStateChange } = options;
+
+  try {
+    if (onLoadingStateChange) onLoadingStateChange(true);
+
+    const participantPKs = participants.map(item => item.participant_pk);
+    const { data } = await client.query({
+      query: GET_COHORT_METADATA_QUERY,
+      variables: {
+        "participant_pk": participantPKs,
+        "first": DEFAULT_QUERY_LIMIT
+      },
+    });
+
+    objectToJsonDownload(data['cohortMetadata'], cohortId);
+    if (showAlert) showAlert('success', 'Metadata JSON downloaded successfully!');
+
+    return data;
+  } catch (error) {
+    console.error('Error downloading cohort metadata:', error);
+    if (showAlert) showAlert('error', 'Failed to download metadata. Please try again.');
+    throw error;
   } finally {
     if (onLoadingStateChange) onLoadingStateChange(false);
   }

--- a/src/pages/CohortAnalyzer/downloadCohort/DownloadSelectedCohorts.js
+++ b/src/pages/CohortAnalyzer/downloadCohort/DownloadSelectedCohorts.js
@@ -1,9 +1,7 @@
 import { Button, makeStyles } from '@material-ui/core';
 import React, { useEffect, useRef, useState } from 'react';
 import ExpandMoreIcon from '../../../assets/icons/Expand_More_Icon.svg'
-import { arrayToCSVDownload, objectToJsonDownload } from '../../../components/CohortModal/utils';
-import client from '../../../utils/graphqlClient';
-import { GET_COHORT_MANIFEST_QUERY, GET_COHORT_METADATA_QUERY } from '../../../bento/dashboardTabData';
+import { downloadCohortManifest, downloadCohortMetadata } from '../../../components/CohortModal/utils';
 
 export default function DownloadSelectedCohort({ queryVariable, isSelected }) {
 
@@ -20,20 +18,20 @@ export default function DownloadSelectedCohort({ queryVariable, isSelected }) {
         }
     }
 
-    const downloadCohortManifest = async () => {
-        const { data } = await client.query({
-            query: GET_COHORT_MANIFEST_QUERY,
-            variables: queryVariable,
-        });
-        arrayToCSVDownload(data['diagnosisOverview'], "analyzed");
+    const handleDownloadManifest = async () => {
+        // Extract participant PKs from queryVariable for centralized function
+        const participants = queryVariable.participant_pk ?
+            queryVariable.participant_pk.map(pk => ({ participant_pk: pk })) : [];
+
+        await downloadCohortManifest(participants, "analyzed");
     };
 
-    const downloadCohortMetadata = async () => {
-        const { data } = await client.query({
-            query: GET_COHORT_METADATA_QUERY,
-            variables: queryVariable,
-        });
-        objectToJsonDownload(data['cohortMetadata'], "Analyzed");
+    const handleDownloadMetadata = async () => {
+        // Extract participant PKs from queryVariable for centralized function
+        const participants = queryVariable.participant_pk ?
+            queryVariable.participant_pk.map(pk => ({ participant_pk: pk })) : [];
+
+        await downloadCohortMetadata(participants, "Analyzed");
     };
     
     useEffect(() => {
@@ -76,13 +74,13 @@ export default function DownloadSelectedCohort({ queryVariable, isSelected }) {
                 <div className={classes.dropdownMenu}>
                     <div
                         className={classes.dropdownItem + ' ' + classes.firstDropdownItem}
-                        onClick={() => { handleDownloadFile(downloadCohortManifest) }}
+                        onClick={() => { handleDownloadFile(handleDownloadManifest) }}
                     >
                         Manifest CSV
                     </div>
                     <div
                         className={classes.dropdownItem}
-                        onClick={() => { handleDownloadFile(downloadCohortMetadata) }}
+                        onClick={() => { handleDownloadFile(handleDownloadMetadata) }}
                     >
                         Metadata JSON
                     </div>


### PR DESCRIPTION
[C3DC-1852](https://tracker.nci.nih.gov/browse/C3DC-1852)
The issue was that the download functionality seemed to be inconsistent across the page. This was due to the action button getting the 'first' value equal to the participant count. This led to data being truncated.

To resolve this, I've centralized the function to the util file and have both instances of the download button point to this one implementation. It uses the max limit of 60k which is configured in the cohort modal data file.

I've also gone ahead and added logic to disable the download button on the cohort analyzer page so that it matches the behavior of the modal.