### PR TITLE
C3DC-2136

### DIFF
--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -72,11 +72,11 @@ export const navMobileList = [
        className: 'navMobileItem clickable',
   },
   {
-    name: 'CCDI Hub in C3DC',
+    name: 'CCDI Hub',
     link: 'https://ccdi.cancer.gov/',
     className: 'navMobileItem',
     externalLink: true,
-  }
+  },
   /*
   {
     name: 'My File',

--- a/src/bento/globalHeaderData.js
+++ b/src/bento/globalHeaderData.js
@@ -70,7 +70,14 @@ export const navMobileList = [
        name: 'About',
        link: '',
        className: 'navMobileItem clickable',
-  },/*
+  },
+  {
+    name: 'CCDI Hub in C3DC',
+    link: 'https://ccdi.cancer.gov/',
+    className: 'navMobileItem',
+    externalLink: true,
+  }
+  /*
   {
     name: 'My File',
     link: '/fileCentricCart',

--- a/src/components/ResponsiveHeader/HeaderMobile.js
+++ b/src/components/ResponsiveHeader/HeaderMobile.js
@@ -269,12 +269,16 @@ const Header = () => {
                             const mobilekey = `mobile_${idx}`;
                             return (
                                 <>
-                                    {navMobileItem.className === 'navMobileItem' && navMobileItem.externalLink ? (
-                                        <a href={navMobileItem.link} target="_blank" rel="noopener noreferrer" key={mobilekey} onClick={() => setNavMobileDisplay('none')}>
-                                            <div className='navMobileItem'>{navMobileItem.name}</div>
-                                        </a>
-                                    ) : (
-                                        navMobileItem.className === 'navMobileItem' && <NavLink to={navMobileItem.link} state={{ navigationType: 'main_menu' }} key={mobilekey} onClick={() => setNavMobileDisplay('none')}><div className='navMobileItem'>{navMobileItem.name}</div></NavLink>
+                                    {navMobileItem.className === 'navMobileItem' && (
+                                        navMobileItem.externalLink ? (
+                                            <a href={navMobileItem.link} target="_blank" rel="noopener noreferrer" key={mobilekey} onClick={() => setNavMobileDisplay('none')}>
+                                                <div className='navMobileItem'>{navMobileItem.name}</div>
+                                            </a>
+                                        ) : (
+                                            <NavLink to={navMobileItem.link} state={{ navigationType: 'main_menu' }} key={mobilekey} onClick={() => setNavMobileDisplay('none')}>
+                                                <div className='navMobileItem'>{navMobileItem.name}</div>
+                                            </NavLink>
+                                        )
                                     )}
                                     {navMobileItem.className === 'navMobileItem clickable' && <div key={mobilekey} className='navMobileItem clickable' onClick={clickNavItem}>{navMobileItem.name}</div>}
                                     {navMobileItem.className === 'navMobileSubItem' && <a href={navMobileItem.link} target={navMobileItem.externalLink ? "_blank" : ""} rel="noopener noreferrer" key={mobilekey}><div className='navMobileItem SubItem' onClick={() => setNavMobileDisplay('none')}>{navMobileItem.name}</div></a>}

--- a/src/components/ResponsiveHeader/HeaderMobile.js
+++ b/src/components/ResponsiveHeader/HeaderMobile.js
@@ -269,7 +269,13 @@ const Header = () => {
                             const mobilekey = `mobile_${idx}`;
                             return (
                                 <>
-                                    {navMobileItem.className === 'navMobileItem' && <NavLink to={navMobileItem.link} state={{ navigationType: 'main_menu' }} key={mobilekey} onClick={() => setNavMobileDisplay('none')}><div className='navMobileItem'>{navMobileItem.name}</div></NavLink>}
+                                    {navMobileItem.className === 'navMobileItem' && navMobileItem.externalLink ? (
+                                        <a href={navMobileItem.link} target="_blank" rel="noopener noreferrer" key={mobilekey} onClick={() => setNavMobileDisplay('none')}>
+                                            <div className='navMobileItem'>{navMobileItem.name}</div>
+                                        </a>
+                                    ) : (
+                                        navMobileItem.className === 'navMobileItem' && <NavLink to={navMobileItem.link} state={{ navigationType: 'main_menu' }} key={mobilekey} onClick={() => setNavMobileDisplay('none')}><div className='navMobileItem'>{navMobileItem.name}</div></NavLink>
+                                    )}
                                     {navMobileItem.className === 'navMobileItem clickable' && <div key={mobilekey} className='navMobileItem clickable' onClick={clickNavItem}>{navMobileItem.name}</div>}
                                     {navMobileItem.className === 'navMobileSubItem' && <a href={navMobileItem.link} target={navMobileItem.externalLink ? "_blank" : ""} rel="noopener noreferrer" key={mobilekey}><div className='navMobileItem SubItem' onClick={() => setNavMobileDisplay('none')}>{navMobileItem.name}</div></a>}
                                     {navMobileItem.className === 'cart' && <NavLink to={navBarCartData.cartLink} key='cart_key' onClick={() => setNavMobileDisplay('none')}><div className='navMobileItem' style={{fontWeight: '600'}}>MY FILES</div></NavLink>}

--- a/src/components/ResponsiveHeader/HeaderTablet.js
+++ b/src/components/ResponsiveHeader/HeaderTablet.js
@@ -268,7 +268,13 @@ const Header = () => {
                             const mobilekey = `mobile_${idx}`;
                             return (
                                 <>
-                                    {navMobileItem.className === 'navMobileItem' && <NavLink to={navMobileItem.link} state={{ navigationType: 'main_menu' }} key={mobilekey} onClick={() => setNavMobileDisplay('none')}><div className='navMobileItem'>{navMobileItem.name}</div></NavLink>}
+                                    {navMobileItem.className === 'navMobileItem' && navMobileItem.externalLink ? (
+                                        <a href={navMobileItem.link} target="_blank" rel="noopener noreferrer" key={mobilekey} onClick={() => setNavMobileDisplay('none')}>
+                                            <div className='navMobileItem'>{navMobileItem.name}</div>
+                                        </a>
+                                    ) : (
+                                        navMobileItem.className === 'navMobileItem' && <NavLink to={navMobileItem.link} state={{ navigationType: 'main_menu' }} key={mobilekey} onClick={() => setNavMobileDisplay('none')}><div className='navMobileItem'>{navMobileItem.name}</div></NavLink>
+                                    )}
                                     {navMobileItem.className === 'navMobileItem clickable' && <div key={mobilekey} className='navMobileItem clickable' onClick={clickNavItem}>{navMobileItem.name}</div>}
                                     {navMobileItem.className === 'navMobileSubItem' && <a href={navMobileItem.link} target={navMobileItem.externalLink ? "_blank" : ""} rel="noopener noreferrer" key={mobilekey}><div className='navMobileItem SubItem' onClick={() => setNavMobileDisplay('none')}>{navMobileItem.name}</div></a>}
                                     {navMobileItem.className === 'cart' && <NavLink to={navBarCartData.cartLink} key='cart_key' onClick={() => setNavMobileDisplay('none')}><div className='navMobileItem' style={{fontWeight: '600'}}>MY FILES</div></NavLink>}

--- a/src/components/ResponsiveHeader/HeaderTablet.js
+++ b/src/components/ResponsiveHeader/HeaderTablet.js
@@ -268,12 +268,16 @@ const Header = () => {
                             const mobilekey = `mobile_${idx}`;
                             return (
                                 <>
-                                    {navMobileItem.className === 'navMobileItem' && navMobileItem.externalLink ? (
-                                        <a href={navMobileItem.link} target="_blank" rel="noopener noreferrer" key={mobilekey} onClick={() => setNavMobileDisplay('none')}>
-                                            <div className='navMobileItem'>{navMobileItem.name}</div>
-                                        </a>
-                                    ) : (
-                                        navMobileItem.className === 'navMobileItem' && <NavLink to={navMobileItem.link} state={{ navigationType: 'main_menu' }} key={mobilekey} onClick={() => setNavMobileDisplay('none')}><div className='navMobileItem'>{navMobileItem.name}</div></NavLink>
+                                    {navMobileItem.className === 'navMobileItem' && (
+                                        navMobileItem.externalLink ? (
+                                            <a href={navMobileItem.link} target="_blank" rel="noopener noreferrer" key={mobilekey} onClick={() => setNavMobileDisplay('none')}>
+                                                <div className='navMobileItem'>{navMobileItem.name}</div>
+                                            </a>
+                                        ) : (
+                                            <NavLink to={navMobileItem.link} state={{ navigationType: 'main_menu' }} key={mobilekey} onClick={() => setNavMobileDisplay('none')}>
+                                                <div className='navMobileItem'>{navMobileItem.name}</div>
+                                            </NavLink>
+                                        )
                                     )}
                                     {navMobileItem.className === 'navMobileItem clickable' && <div key={mobilekey} className='navMobileItem clickable' onClick={clickNavItem}>{navMobileItem.name}</div>}
                                     {navMobileItem.className === 'navMobileSubItem' && <a href={navMobileItem.link} target={navMobileItem.externalLink ? "_blank" : ""} rel="noopener noreferrer" key={mobilekey}><div className='navMobileItem SubItem' onClick={() => setNavMobileDisplay('none')}>{navMobileItem.name}</div></a>}

--- a/src/components/ResponsiveHeader/components/NavbarDesktop.js
+++ b/src/components/ResponsiveHeader/components/NavbarDesktop.js
@@ -272,17 +272,30 @@ const NavBar = () => {
                   &&
                   <LiSection key={navkey}>
                     <div className='navTitle directLink'>
-                      <NavLink to={navMobileItem.link}>
-                        <div
-                          className='navText directLink'
-                          onKeyDown={onKeyPressHandler}
-                          role="button"
-                          onClick={handleMenuClick}
-                          style={path === navMobileItem.link || (path === '/' && navMobileItem.link === '/home') ? activeStyle : null}
-                        >
-                          {navMobileItem.name}
+                      {navMobileItem.externalLink ? (
+                        <a href={navMobileItem.link} target="_blank" rel="noopener noreferrer">
+                          <div
+                            className='navText directLink'
+                            onKeyDown={onKeyPressHandler}
+                            role="button"
+                            onClick={handleMenuClick}
+                          >
+                            {navMobileItem.name}
+                          </div>
+                        </a>
+                      ) : (
+                        <NavLink to={navMobileItem.link}>
+                          <div
+                            className='navText directLink'
+                            onKeyDown={onKeyPressHandler}
+                            role="button"
+                            onClick={handleMenuClick}
+                            style={path === navMobileItem.link || (path === '/' && navMobileItem.link === '/home') ? activeStyle : null}
+                          >
+                            {navMobileItem.name}
                           </div>
                         </NavLink>
+                      )}
                       </div>
                     </LiSection>
                 }

--- a/src/components/ResponsiveHeader/components/NavbarDesktop.js
+++ b/src/components/ResponsiveHeader/components/NavbarDesktop.js
@@ -273,15 +273,15 @@ const NavBar = () => {
                   <LiSection key={navkey}>
                     <div className='navTitle directLink'>
                       {navMobileItem.externalLink ? (
-                        <a href={navMobileItem.link} target="_blank" rel="noopener noreferrer">
-                          <div
-                            className='navText directLink'
-                            onKeyDown={onKeyPressHandler}
-                            role="button"
-                            onClick={handleMenuClick}
-                          >
-                            {navMobileItem.name}
-                          </div>
+                        <a 
+                          href={navMobileItem.link} 
+                          target="_blank" 
+                          rel="noopener noreferrer"
+                          className='navText directLink'
+                          onKeyDown={onKeyPressHandler}
+                          onClick={handleMenuClick}
+                        >
+                          {navMobileItem.name}
                         </a>
                       ) : (
                         <NavLink to={navMobileItem.link}>


### PR DESCRIPTION
### Overview

This branch (C3DC-2129) adds a new navigation header link for CCDI Hub.

### Change Details (Specifics)

**Navigation & Header Updates:**
- Added "CCDI Hub in C3DC" header link after the "About" tab
- Implemented external link handling in responsive header components (Desktop, Mobile, Tablet)
- Link opens CCDI Hub landing page (https://ccdi.cancer.gov/) in a new tab


**Files Modified:**
- `src/bento/globalHeaderData.js` - Added CCDI Hub navigation item
- `src/components/ResponsiveHeader/components/NavbarDesktop.js` - External link support
- `src/components/ResponsiveHeader/HeaderMobile.js` - External link support
- `src/components/ResponsiveHeader/HeaderTablet.js` - External link support


### Related Ticket(s)

C3DC-2129
