### PR TITLE
* Linting issues addressed

### DIFF
--- a/src/pages/CohortAnalyzer/CohortAnalyzer.js
+++ b/src/pages/CohortAnalyzer/CohortAnalyzer.js
@@ -31,7 +31,6 @@ import { CohortAnalyzerChartArea } from './components/CohortAnalyzerChartArea';
 import { CohortAnalyzerSummaryView } from './components/CohortAnalyzerSummaryView';
 import { getJoinedCohortData } from "./CohortAnalyzerUtil/CohortDataTransform";
 import { exampleCohorts, getExampleCohortKeys } from "../../bento/exampleCohortData";
-import { exportToCCDIHub } from "../../components/CohortModal/utils";
 import { useUserGuide } from '../inventory/sideBar/UserGuideContext';
 import { USER_GUIDE_SECTION_ANALYZING_COHORTS } from '../inventory/sideBar/userGuideConstants';
 
@@ -112,21 +111,6 @@ export const CohortAnalyzer = () => {
         } else {
             setShowNavigateAwayModal(true); // show modal
         }
-    }
-
-    const handleExportToCCDIHub = async () => {
-        // Use centralized export function with Cohort Analyzer context
-        await exportToCCDIHub(rowData, {
-            showAlert: (type, message) => {
-                // Convert to Cohort Analyzer's notification system
-                if (type === 'success') {
-                    Notification.show(message, 3000);
-                } else if (type === 'error' || type === 'warning') {
-                    Notification.show(message, 5000);
-                }
-            },
-            useInteropService: true
-        });
     }
 
     const searchRef = useRef();
@@ -484,7 +468,6 @@ export const CohortAnalyzer = () => {
                                 questionIcon={questionIcon}
                                 handleClick={handleClick}
                                 handleBuildInExplore={handleBuildInExplore}
-                                handleExportToCCDIHub={handleExportToCCDIHub}
                                 initTblState={initTblState}
                                 themeConfig={cohortAnalyzerThemeConfig}
                             />

--- a/src/pages/CohortAnalyzer/CohortAnalyzerTableSection/CohortAnalyzerTableSection.js
+++ b/src/pages/CohortAnalyzer/CohortAnalyzerTableSection/CohortAnalyzerTableSection.js
@@ -2,8 +2,7 @@ import React, { useMemo, useCallback } from 'react';
 import { TableView } from '@bento-core/paginated-table';
 import { CreateNewCohortButton } from '../CreateNewCohortButton/CreateNewCohortButton';
 import DownloadSelectedCohort from '../downloadCohort/DownloadSelectedCohorts';
-import { exploreCCDIHubTooltip, exploreDashboardTooltip } from '../config/CohortAnalyzerConfig';
-import linkoutIcon from '../../../assets/landing/Export_Icon_White.svg';
+import { exploreDashboardTooltip } from '../config/CohortAnalyzerConfig';
 import { useCohortAnalyzer } from '../context/CohortAnalyzerContext';
 import { ButtonWithTooltip } from './ButtonWithTooltip';
 
@@ -11,22 +10,16 @@ const row = { display: 'flex', alignItems: 'center' };
 const bar = { display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 12, flexWrap: 'wrap' };
 
 
-const CohortAnalyzerTableSection = ({ classes, questionIcon, handleClick, handleBuildInExplore, handleExportToCCDIHub, themeConfig, initTblState }) => {
+const CohortAnalyzerTableSection = ({ classes, questionIcon, handleClick, handleBuildInExplore, themeConfig, initTblState }) => {
   const { selectedCohortSection, queryVariable, selectedCohorts, rowData, refreshTableContent } = useCohortAnalyzer();
 
 
   const hasSel = useMemo(() => selectedCohorts.length > 0, [selectedCohorts]);
   const hasRows = useMemo(() => rowData.length > 0, [rowData]);
   const canBuild = hasSel;
-  const canHub = hasSel && hasRows;
 
 
   const onBuild = useCallback(() => canBuild && handleBuildInExplore(), [canBuild, handleBuildInExplore]);
-  const onHub = useCallback(async () => {
-    if (canHub) {
-      await handleExportToCCDIHub();
-    }
-  }, [canHub, handleExportToCCDIHub]);
 
 
   return (

--- a/src/pages/CohortAnalyzer/styling/summaryStyles.js
+++ b/src/pages/CohortAnalyzer/styling/summaryStyles.js
@@ -175,7 +175,6 @@ export const cohortAnalyzerSummaryStyles = (theme) => ({
     padding: '8px 16px',
     cursor: 'pointer',
     marginRight: 0,
-    textAlign: 'left',
     whiteSpace: 'nowrap',
     display: 'flex',
     alignItems: 'center',

--- a/src/pages/CohortAnalyzer/vennDiagram/ChartVennConfig.js
+++ b/src/pages/CohortAnalyzer/vennDiagram/ChartVennConfig.js
@@ -92,8 +92,9 @@ function wrapVennTextToWidth(ctx, text, maxWidth, maxLines) {
       line = '';
     }
   };
-  for (const word of words) {
-    const test = line ? `${line} ${word}` : word;
+  for (let wi = 0; wi < words.length; wi += 1) {
+    const w = words[wi];
+    const test = line ? `${line} ${w}` : w;
     if (ctx.measureText(test).width <= maxWidth) {
       line = test;
     } else {
@@ -101,11 +102,12 @@ function wrapVennTextToWidth(ctx, text, maxWidth, maxLines) {
       if (lines.length >= maxLines) {
         return lines.slice(0, maxLines);
       }
-      if (ctx.measureText(word).width <= maxWidth) {
-        line = word;
+      if (ctx.measureText(w).width <= maxWidth) {
+        line = w;
         continue;
       }
-      for (const ch of word) {
+      for (let i = 0; i < w.length; i += 1) {
+        const ch = w.charAt(i);
         const t2 = line + ch;
         if (ctx.measureText(t2).width > maxWidth && line) {
           lines.push(line);


### PR DESCRIPTION
Overview
Brings the cohort analyzer and Venn text-wrapping code in line with ESLint (--max-warnings=0), removes dead export-to-CCDI-hub wiring that lint surfaced, and cleans up a duplicate style key. No intended UI or behavior change beyond dropping unused export plumbing.

Change Details (Specifics)
CohortAnalyzerTableSection: Removed unused imports and the unused export-to-CCDI-Hub callback/props so the table toolbar matches what is actually rendered (Explore dashboard button path only).
CohortAnalyzer: Removed the orphaned handleExportToCCDIHub handler and exportToCCDIHub import, and stopped passing the unused prop into CohortAnalyzerTableSection.
summaryStyles: Resolved duplicate textAlign on summaryTab (kept centered alignment consistent with flex layout).
ChartVennConfig: Adjusted the word-wrap loops (indexed outer loop + character iteration) to satisfy no-unused-vars under the project’s Babel/ESLint setup without changing wrap logic.