### PR TITLE
Empty state

### DIFF
--- a/src/pages/CohortAnalyzer/HistogramPanel/Histogram.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/Histogram.js
@@ -48,8 +48,13 @@ import {
   SurvivalHistogramInlineLegacy,
 } from './survival/HistogramSurvivalLayoutFragments';
 import { SurvivalAnalysisCardBody } from './survival/SurvivalAnalysisCardBody';
+import {
+  areChartsInteractionDisabled,
+  getChartPreviewContentStyle,
+} from '../utils/cohortAnalyzerChartPreview';
 
 const Histogram = ({
+  chartPreviewMode = false,
   c1,
   c2,
   c3,
@@ -130,6 +135,7 @@ const Histogram = ({
     c1,
     c2,
     c3,
+    chartPreviewMode,
     expandedChart: chartModalExpandedChart,
     setExpandedChart: setChartModalExpandedChart,
     activeTab: chartModalActiveTab,
@@ -374,16 +380,18 @@ const Histogram = ({
   };
 
   const allInputsEmpty = [c1, c2, c3].every(arr => !Array.isArray(arr) || arr.length === 0);
+  const chartsInteractionDisabled = areChartsInteractionDisabled(allInputsEmpty, chartPreviewMode);
+  const chartPreviewStyle = getChartPreviewContentStyle(chartPreviewMode);
 
   const survivalBesideVennCardStyle = useSurvivalBesideVennCardStyle({
     survivalCardSize,
     besideCardDrag,
-    allInputsEmpty,
+    allInputsEmpty: chartsInteractionDisabled,
     besidePanelDragState,
   });
 
   const { handleHistogramCardResizeStart, handleSurvivalCardResizeStart } = useHistogramResizeHandlers({
-    allInputsEmpty,
+    allInputsEmpty: chartsInteractionDisabled,
     histogramCardSizes,
     setHistogramCardSizes,
     survivalCardSize,
@@ -395,7 +403,11 @@ const Histogram = ({
 
   const survivalAnalysisBodyProps = {
     classes,
-    allInputsEmpty,
+    chartPreviewMode,
+    c1Name,
+    c2Name,
+    c3Name,
+    allInputsEmpty: chartsInteractionDisabled,
     besideCardDrag,
     survivalCardSize,
     kmChartRef,
@@ -424,7 +436,8 @@ const Histogram = ({
         draggingDataset={draggingDataset}
         chartRef={chartRef}
         histogramCardSizes={histogramCardSizes}
-        allInputsEmpty={allInputsEmpty}
+        allInputsEmpty={chartsInteractionDisabled}
+        chartPreviewMode={chartPreviewMode}
         beginStripChartDrag={beginStripChartDrag}
         endStripChartDrag={endStripChartDrag}
         setDragOverDataset={setDragOverDataset}
@@ -462,7 +475,7 @@ const Histogram = ({
         besideCardDrag={besideCardDrag}
         survivalBesideVennCardStyle={survivalBesideVennCardStyle}
         survivalAnalysisBodyProps={survivalAnalysisBodyProps}
-        allInputsEmpty={allInputsEmpty}
+        allInputsEmpty={chartsInteractionDisabled}
         handleSurvivalCardResizeStart={handleSurvivalCardResizeStart}
       />
       <CenterContainer
@@ -480,7 +493,7 @@ const Histogram = ({
           survivalBesideVennTarget={survivalBesideVennTarget}
           survivalCardSize={survivalCardSize}
           survivalAnalysisBodyProps={survivalAnalysisBodyProps}
-          allInputsEmpty={allInputsEmpty}
+          allInputsEmpty={chartsInteractionDisabled}
           handleSurvivalCardResizeStart={handleSurvivalCardResizeStart}
           stripOrder={stripOrder}
           topRowOrder={topRowOrder}
@@ -497,6 +510,7 @@ const Histogram = ({
                 }}
                 style={{
                   ...stripVennChartWrapperStyle,
+                  ...chartPreviewStyle,
                   cursor: 'default',
                 }}
                 draggable={false}
@@ -505,6 +519,7 @@ const Histogram = ({
               >
                 <VennDiagramContainer
                   state={cohortParticipantState}
+                  chartPreviewMode={chartPreviewMode}
                   containerRef={containerRef}
                   canvasRef={canvasRef}
                   classes={classes}
@@ -529,9 +544,10 @@ const Histogram = ({
                 }}
                 style={{
                   ...stripSurvivalChartWrapperStyle,
-                  cursor: allInputsEmpty ? 'default' : 'grab',
+                  ...chartPreviewStyle,
+                  cursor: chartsInteractionDisabled ? 'default' : 'grab',
                 }}
-                draggable={!allInputsEmpty}
+                draggable={!chartsInteractionDisabled}
                 onDragStart={(event) => {
                   setDragOverDataset(null);
                   captureHistogramDragCardSize(event, ds);
@@ -556,7 +572,7 @@ const Histogram = ({
                   aria-label="Resize survival analysis card"
                   title="Drag to resize card"
                   onMouseDown={handleSurvivalCardResizeStart}
-                  style={{ opacity: allInputsEmpty ? 0.35 : 1, pointerEvents: allInputsEmpty ? 'none' : 'auto' }}
+                  style={{ opacity: chartsInteractionDisabled ? 0.35 : 1, pointerEvents: chartsInteractionDisabled ? 'none' : 'auto' }}
                 />
               </ChartWrapper>
             );
@@ -590,7 +606,8 @@ const Histogram = ({
             handleStripChartDrop={handleStripChartDrop}
             handleHistogramCardResizeStart={handleHistogramCardResizeStart}
             chartRef={chartRef}
-            allInputsEmpty={allInputsEmpty}
+            allInputsEmpty={chartsInteractionDisabled}
+            chartPreviewMode={chartPreviewMode}
             getChartTitle={getChartTitle}
             chartTypeMenuDataset={chartTypeMenuDataset}
             setChartTypeMenuDataset={setChartTypeMenuDataset}

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
@@ -114,6 +114,7 @@ export function HistogramDatasetChart({
   c1Name = 'Cohort A',
   c2Name = 'Cohort B',
   c3Name = 'Cohort C',
+  previewShell = false,
 }) {
   const bottomMargin = compact ? 12 : 0;
   const yAxisTickFormatter = (value) => {
@@ -148,6 +149,34 @@ export function HistogramDatasetChart({
     lineHeight: compact ? 10 : 11,
     letterSpacing: 0,
   };
+
+  if (previewShell) {
+    const shellMargin = {
+      top: 20,
+      right: 30,
+      left: 10,
+      bottom: bottomMargin,
+    };
+    return (
+      <ResponsiveContainer width={width} height={height}>
+        <BarChart data={[{ name: ' ' }]} margin={shellMargin}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" horizontal vertical={false} />
+          <XAxis
+            dataKey="name"
+            interval={0}
+            tick={false}
+            axisLine={{ stroke: '#e0e0e0' }}
+            height={xAxisHeight}
+          />
+          <YAxis
+            domain={[0, 100]}
+            tickFormatter={yAxisTickFormatter}
+            tick={yAxisTickStyle}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  }
 
   if (chartType === CHART_TYPE_KEYS.PIE) {
     const pieData = buildPieData(rows);

--- a/src/pages/CohortAnalyzer/HistogramPanel/hooks/useHistogramData.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/hooks/useHistogramData.js
@@ -6,6 +6,7 @@ export const useHistogramData = ({
   c1 = [],
   c2 = [],
   c3 = [],
+  chartPreviewMode = false,
   expandedChart,
   setExpandedChart,
   activeTab,
@@ -195,8 +196,12 @@ const fetchChartData = async () => {
 
   
   useEffect(() => {
-    fetchChartData(); // Only runs once to fetch simulated data
-  }, [c1, c2, c3, viewType]);
+    if (chartPreviewMode) {
+      setFetchedData({});
+      return;
+    }
+    fetchChartData();
+  }, [c1, c2, c3, viewType, chartPreviewMode]);
 
   // Reset checkboxes to default when all cohorts are empty
   useEffect(() => {

--- a/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramBesideVennHistogramPortal.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramBesideVennHistogramPortal.js
@@ -23,6 +23,7 @@ import {
 } from '../../store/panelDnD';
 import { requiresCompactSpacing, HISTOGRAM_DRAG_SOURCE_COLLAPSED_STYLE } from '../utils/histogramLayoutUtils';
 import { HistogramChartEmptyState } from '../chart/HistogramChartEmptyState';
+import { getChartPreviewContentStyle } from '../../utils/cohortAnalyzerChartPreview';
 
 export function HistogramBesideVennHistogramPortal({
   survivalSelected,
@@ -31,6 +32,7 @@ export function HistogramBesideVennHistogramPortal({
   chartRef,
   histogramCardSizes,
   allInputsEmpty,
+  chartPreviewMode = false,
   beginStripChartDrag,
   endStripChartDrag,
   setDragOverDataset,
@@ -74,6 +76,9 @@ export function HistogramBesideVennHistogramPortal({
     besidePeerShellBox && besideColumnPlotHeightPx != null
       ? besideColumnPlotHeightPx
       : besideStripPlotHeight;
+  const hasDatasetData = Array.isArray(data[d]) && data[d].length > 0;
+  const showChartBody = chartPreviewMode || hasDatasetData;
+  const chartPreviewStyle = getChartPreviewContentStyle(chartPreviewMode);
 
   return createPortal(
     <ChartWrapper
@@ -102,6 +107,7 @@ export function HistogramBesideVennHistogramPortal({
                 maxWidth: 'none',
               }
               : {}),
+        ...chartPreviewStyle,
         cursor: allInputsEmpty ? 'default' : 'grab',
       }}
       draggable={!allInputsEmpty}
@@ -123,7 +129,7 @@ export function HistogramBesideVennHistogramPortal({
       }}
     >
       <HeaderSection>
-        <ChartTitle className={`${Array.isArray(data[d]) && data[d].length > 0 ? '' : 'empty'}`}>
+        <ChartTitle className={`${showChartBody ? '' : 'empty'}`}>
           <span
             role="button"
             tabIndex={0}
@@ -214,7 +220,7 @@ export function HistogramBesideVennHistogramPortal({
         className={classes.chartContentWrapper}
         style={{ paddingBottom: requiresCompactSpacing(d) ? '12px' : '0px' }}
       >
-        {Array.isArray(data[d]) && data[d].length > 0 ? (
+        {showChartBody ? (
           <div
             className={classes.chartPlotArea}
             style={{
@@ -223,8 +229,8 @@ export function HistogramBesideVennHistogramPortal({
             }}
           >
             <HistogramDatasetChart
-              rows={filteredData[d]}
-              viewType={viewType[d]}
+              rows={chartPreviewMode ? [] : filteredData[d]}
+              viewType={viewType[d] || 'percentage'}
               chartType={chartVisualByPanelId[d] || DEFAULT_CHART_TYPE}
               valueA={besideHistogramBarSums.valueA}
               valueB={besideHistogramBarSums.valueB}
@@ -246,6 +252,7 @@ export function HistogramBesideVennHistogramPortal({
               c1Name={c1Name || 'Cohort A'}
               c2Name={c2Name || 'Cohort B'}
               c3Name={c3Name || 'Cohort C'}
+              previewShell={chartPreviewMode}
             />
           </div>
         ) : (

--- a/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramStripChartRow.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramStripChartRow.js
@@ -30,6 +30,7 @@ import {
 import { requiresCompactSpacing, HISTOGRAM_DRAG_SOURCE_COLLAPSED_STYLE } from '../utils/histogramLayoutUtils';
 import { HistogramChartEmptyState } from '../chart/HistogramChartEmptyState';
 import { HISTOGRAM_STRIP_DROP_SLOT_WIDTH_EXTRA_PX } from '../histogramConstants';
+import { getChartPreviewContentStyle } from '../../utils/cohortAnalyzerChartPreview';
 
 export function HistogramStripChartRow({
   dataset,
@@ -58,6 +59,7 @@ export function HistogramStripChartRow({
   handleHistogramCardResizeStart,
   chartRef,
   allInputsEmpty,
+  chartPreviewMode = false,
   getChartTitle,
   chartTypeMenuDataset,
   setChartTypeMenuDataset,
@@ -99,6 +101,9 @@ export function HistogramStripChartRow({
   const estimatedChartW = cardSize && cardSize.width != null
     ? Math.max(280, cardSize.width - 48)
     : 400;
+  const hasDatasetData = Array.isArray(data[dataset]) && data[dataset].length > 0;
+  const showChartBody = chartPreviewMode || hasDatasetData;
+  const chartPreviewStyle = getChartPreviewContentStyle(chartPreviewMode);
   const topRowSnap = besidePanelDraggingRef && besidePanelDraggingRef.current;
   const topRowStripDrag =
     topRowSnap &&
@@ -192,6 +197,7 @@ export function HistogramStripChartRow({
               ...(chartWrapperStyle || {}),
               ...peerShadowStyle,
               ...dropTargetStyle,
+              ...chartPreviewStyle,
               opacity: cardDragOpacity,
             }),
           cursor: allInputsEmpty ? 'default' : 'grab',
@@ -357,7 +363,7 @@ export function HistogramStripChartRow({
           }}
         >
 
-          {Array.isArray(data[dataset]) && data[dataset].length > 0 ? (
+          {showChartBody ? (
             <>
               <fieldset style={{ border: 'none', width: '100%', margin: 0, padding: 0 }}>
                 <legend style={{ position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 }}>
@@ -391,8 +397,8 @@ export function HistogramStripChartRow({
                 style={{ minHeight: plotH, height: plotH }}
               >
                 <HistogramDatasetChart
-                  rows={filteredData[dataset]}
-                  viewType={viewType[dataset]}
+                  rows={chartPreviewMode ? [] : filteredData[dataset]}
+                  viewType={viewType[dataset] || 'percentage'}
                   chartType={chartVisualByPanelId[dataset] || DEFAULT_CHART_TYPE}
                   valueA={valueA}
                   valueB={valueB}
@@ -408,6 +414,7 @@ export function HistogramStripChartRow({
                   c1Name={c1Name || 'Cohort A'}
                   c2Name={c2Name || 'Cohort B'}
                   c3Name={c3Name || 'Cohort C'}
+                  previewShell={chartPreviewMode}
                 />
               </div>
             </>

--- a/src/pages/CohortAnalyzer/HistogramPanel/survival/SurvivalAnalysisCardBody.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/survival/SurvivalAnalysisCardBody.js
@@ -31,6 +31,11 @@ import {
   downloadSurvivalCombined,
 } from '../utils/histogramSurvivalDownloads';
 import { HistogramChartEmptyState } from '../chart/HistogramChartEmptyState';
+import {
+  buildPlaceholderSurvivalRiskCohorts,
+  CHART_PREVIEW_KM_COLORS,
+  CHART_PREVIEW_RISK_TIME_INTERVALS,
+} from '../../utils/cohortAnalyzerChartPreview';
 
 /**
  * Survival analysis card: header actions, KM plot, and risk table (inline or beside Venn).
@@ -38,6 +43,10 @@ import { HistogramChartEmptyState } from '../chart/HistogramChartEmptyState';
 export function SurvivalAnalysisCardBody({
   besideVenn,
   classes,
+  chartPreviewMode = false,
+  c1Name = '',
+  c2Name = '',
+  c3Name = '',
   allInputsEmpty,
   besideCardDrag,
   survivalCardSize,
@@ -76,9 +85,17 @@ export function SurvivalAnalysisCardBody({
     ),
   );
   const survivalHasNoDisplayData =
-    !kmLoading
+    !chartPreviewMode
+    && !kmLoading
     && !kmError
     && (!Array.isArray(filteredKmPlotData) || filteredKmPlotData.length === 0);
+
+  const previewRiskCohorts = chartPreviewMode
+    ? buildPlaceholderSurvivalRiskCohorts().map((row, index) => {
+      const names = [c1Name || 'Cohort A', c2Name || 'Cohort B', c3Name || 'Cohort C'];
+      return { ...row, name: names[index] || row.name };
+    })
+    : null;
   const survivalBodyMinHeight = Math.max(
     kmHeight + 120,
     Math.round(effectiveSurvivalH - survivalHeaderChromePx),
@@ -90,7 +107,7 @@ export function SurvivalAnalysisCardBody({
   return (
     <>
       <SurvivalAnalysisHeader>
-        <ChartTitle className={survivalHasNoDisplayData ? 'empty' : ''}>
+        <ChartTitle className={!chartPreviewMode && survivalHasNoDisplayData ? 'empty' : ''}>
           <span
             role="button"
             tabIndex={0}
@@ -108,8 +125,8 @@ export function SurvivalAnalysisCardBody({
               justifyContent: 'center',
               flexShrink: 0,
               marginRight: 6,
-              cursor: survivalHasNoDisplayData ? 'not-allowed' : canBesideReorder ? 'grab' : 'default',
-              opacity: survivalHasNoDisplayData ? 0.45 : 1,
+              cursor: (!chartPreviewMode && survivalHasNoDisplayData) ? 'not-allowed' : canBesideReorder ? 'grab' : 'default',
+              opacity: (!chartPreviewMode && survivalHasNoDisplayData) ? 0.45 : 1,
             }}
             title={
               canBesideReorder
@@ -159,16 +176,16 @@ export function SurvivalAnalysisCardBody({
           <button
             type="button"
             aria-label="Expand survival chart"
-            disabled={survivalHasNoDisplayData}
+            disabled={allInputsEmpty || survivalHasNoDisplayData}
             onClick={() => {
-              if (!survivalHasNoDisplayData) {
+              if (!allInputsEmpty && !survivalHasNoDisplayData) {
                 setExpandedChart('survivalAnalysis');
                 setActiveTab('survivalAnalysis');
               }
             }}
-            style={{ padding: 0, background: 'none', border: 'none', cursor: survivalHasNoDisplayData ? 'not-allowed' : 'pointer' }}
+            style={{ padding: 0, background: 'none', border: 'none', cursor: (allInputsEmpty || survivalHasNoDisplayData) ? 'not-allowed' : 'pointer' }}
           >
-            <img src={ExpandIcon} alt="" width={19} height={19} style={{ opacity: survivalHasNoDisplayData ? 0.5 : 1, display: 'block' }} />
+            <img src={ExpandIcon} alt="" width={19} height={19} style={{ opacity: (allInputsEmpty || survivalHasNoDisplayData) ? 0.5 : 1, display: 'block' }} />
           </button>
           <DownloadDropdown ref={dropdownRef}>
             <button
@@ -176,13 +193,13 @@ export function SurvivalAnalysisCardBody({
               aria-label="Survival chart download options"
               aria-expanded={showDownloadDropdown}
               aria-haspopup="menu"
-              disabled={survivalHasNoDisplayData}
-              onClick={() => !survivalHasNoDisplayData && setShowDownloadDropdown(!showDownloadDropdown)}
-              style={{ padding: 0, background: 'none', border: 'none', cursor: survivalHasNoDisplayData ? 'not-allowed' : 'pointer' }}
+              disabled={allInputsEmpty || survivalHasNoDisplayData}
+              onClick={() => !allInputsEmpty && !survivalHasNoDisplayData && setShowDownloadDropdown(!showDownloadDropdown)}
+              style={{ padding: 0, background: 'none', border: 'none', cursor: (allInputsEmpty || survivalHasNoDisplayData) ? 'not-allowed' : 'pointer' }}
             >
-              <img src={DownloadIcon} alt="" width={19} height={19} style={{ opacity: survivalHasNoDisplayData ? 0.5 : 1, display: 'block' }} />
+              <img src={DownloadIcon} alt="" width={19} height={19} style={{ opacity: (allInputsEmpty || survivalHasNoDisplayData) ? 0.5 : 1, display: 'block' }} />
             </button>
-            {showDownloadDropdown && !survivalHasNoDisplayData && (
+            {showDownloadDropdown && !allInputsEmpty && !survivalHasNoDisplayData && (
               <DownloadDropdownMenu role="menu">
                 <DownloadDropdownItem
                   role="menuitem"
@@ -232,7 +249,31 @@ export function SurvivalAnalysisCardBody({
       </SurvivalAnalysisHeader>
 
       <SurvivalAnalysisContainer ref={survivalAnalysisContainerRef}>
-        {survivalHasNoDisplayData ? (
+        {chartPreviewMode ? (
+          <>
+            <KmWrap ref={kmChartRef}>
+              <KaplanMeierChart
+                data={[]}
+                title=""
+                width="100%"
+                height={kmHeight}
+                loading={false}
+                error={null}
+                colors={CHART_PREVIEW_KM_COLORS}
+                showLabels={false}
+                showLegend={false}
+              />
+            </KmWrap>
+            <RiskWrap ref={riskTableRef}>
+              <RiskTable
+                classes={{ cohortName: classes.cohortNameEllipsis }}
+                cohortNameCharLimit={7}
+                cohorts={previewRiskCohorts}
+                timeIntervals={CHART_PREVIEW_RISK_TIME_INTERVALS}
+              />
+            </RiskWrap>
+          </>
+        ) : survivalHasNoDisplayData ? (
           <div
             style={{
               width: '100%',

--- a/src/pages/CohortAnalyzer/components/CohortAnalyzerChartArea.js
+++ b/src/pages/CohortAnalyzer/components/CohortAnalyzerChartArea.js
@@ -12,6 +12,10 @@ import { buildDefaultCohortAnalyzerPanelRegistry } from '../store/cohortAnalyzer
 import { isCohortAnalyzerLayoutPristine } from '../store/cohortAnalyzerLayoutReducer';
 import { CohortAnalyzerDownloadAllDropdown } from './CohortAnalyzerDownloadAllDropdown';
 import { BESIDE_PEER_DRAG_STYLE } from '../HistogramPanel/histogramConstants';
+import {
+    chartPreviewCohortName,
+    getChartPreviewContentStyle,
+} from '../utils/cohortAnalyzerChartPreview';
 
 const ALL_CHARTS_ADDED_TOOLTIP = 'All charts are already added';
 const NO_COHORT_SELECTED_TOOLTIP = 'To proceed, please select a cohort from the cohort list in the left panel.';
@@ -142,16 +146,26 @@ export function CohortAnalyzerChartArea({
         setAllAddableChartsAdded(Boolean(allAdded));
     }, []);
 
+    const chartPreviewMode = !hasParticipantData;
+
     const participantIds = (index) => {
+        if (chartPreviewMode) {
+            return [];
+        }
         const id = selectedCohorts[index];
         if (!id || !state || !state[id]) return [];
         return state[id].participants.map((item) => (item.id ? item.id : item.participant.id));
     };
 
     const cohortName = (index) => {
+        if (chartPreviewMode) {
+            return chartPreviewCohortName(index);
+        }
         const id = selectedCohorts[index];
         return id && state && state[id] ? state[id].cohortName : '';
     };
+
+    const chartPreviewContentStyle = getChartPreviewContentStyle(chartPreviewMode);
 
     const vennColumnDragStyle = {
         ...(besidePanelDragging && besidePanelDragging.kind === 'survival'
@@ -269,7 +283,11 @@ export function CohortAnalyzerChartArea({
                     />
                 </div>
             </div>
-            <div className={classes.chartSummaryMain} ref={chartSummaryExportRef}>
+            <div
+                className={classes.chartSummaryMain}
+                ref={chartSummaryExportRef}
+            >
+                <div style={chartPreviewContentStyle}>
                 {topRowOrder.length > 0 && (
                     <div
                         className={classes.vennSurvivalRow}
@@ -297,6 +315,7 @@ export function CohortAnalyzerChartArea({
                                         <div className={classes.rightSideAnalyzerHeader2} />
                                         <VennDiagramContainer
                                             state={state}
+                                            chartPreviewMode={chartPreviewMode}
                                             containerRef={containerRef}
                                             canvasRef={canvasRef}
                                             classes={classes}
@@ -327,6 +346,7 @@ export function CohortAnalyzerChartArea({
                     </div>
                 )}
                 <Histogram
+                    chartPreviewMode={chartPreviewMode}
                     survivalBesideVennTarget={survivalBesideVennEl}
                     onSurvivalBesideColumnActive={setSurvivalBesideColumnActive}
                     besideCardDrag={survivalBesideDrag}
@@ -353,6 +373,7 @@ export function CohortAnalyzerChartArea({
                                 onTopRowStripDropComplete={endBesidePanelDrag}
                                 onExpandVenn={handleExpandVennInChartModal}
                             />
+                </div>
                 <div
                     ref={addChartScrollAnchorRef}
                     className={classes.chartSummaryHistogramFooter}

--- a/src/pages/CohortAnalyzer/utils/cohortAnalyzerChartPreview.js
+++ b/src/pages/CohortAnalyzer/utils/cohortAnalyzerChartPreview.js
@@ -1,0 +1,54 @@
+/** Visual treatment for chart summary when no cohorts are selected. */
+export const CHART_PREVIEW_CONTENT_STYLE = {
+  opacity: 0.72,
+  filter: 'grayscale(0.35)',
+  pointerEvents: 'none',
+  userSelect: 'none',
+};
+
+export const CHART_PREVIEW_COHORT_LABELS = ['Cohort A', 'Cohort B', 'Cohort C'];
+
+/** Default month columns for empty preview risk table (matches @bento-core/risk-table defaults). */
+export const CHART_PREVIEW_RISK_TIME_INTERVALS = [
+  '0 Months',
+  '6 Months',
+  '12 Months',
+  '18 Months',
+  '24 Months',
+  '30 Months',
+  '36 Months',
+];
+
+const PREVIEW_RISK_COHORT_COLORS = ['#E74C3C', '#3498DB', '#2ECC71'];
+
+export function getChartPreviewContentStyle(chartPreviewMode) {
+  return chartPreviewMode ? CHART_PREVIEW_CONTENT_STYLE : undefined;
+}
+
+export function areChartsInteractionDisabled(allInputsEmpty, chartPreviewMode) {
+  return allInputsEmpty || Boolean(chartPreviewMode);
+}
+
+export function chartPreviewCohortName(index) {
+  return CHART_PREVIEW_COHORT_LABELS[index] || '';
+}
+
+/** Empty Venn cohort slots (labels only — no participants). */
+export function buildPlaceholderVennCohortData() {
+  return CHART_PREVIEW_COHORT_LABELS.map((cohortName) => ({
+    cohortName,
+    participants: [],
+  }));
+}
+
+/** Empty risk-table rows for preview survival card. */
+export function buildPlaceholderSurvivalRiskCohorts() {
+  return CHART_PREVIEW_COHORT_LABELS.map((name, index) => ({
+    id: `c${index + 1}`,
+    name,
+    color: PREVIEW_RISK_COHORT_COLORS[index],
+    data: {},
+  }));
+}
+
+export const CHART_PREVIEW_KM_COLORS = PREVIEW_RISK_COHORT_COLORS;

--- a/src/pages/CohortAnalyzer/vennDiagram/ChartVenn.js
+++ b/src/pages/CohortAnalyzer/vennDiagram/ChartVenn.js
@@ -51,6 +51,7 @@ const ChartVenn = ({
    * inline uses VENN_CANVAS_SIZE_SCALE_BIG_SCREEN instead.
    */
   expandedView = false,
+  chartPreviewMode = false,
 }) => {
   const chartRef = useRef(null);
   /** Observed chart plot box — keeps canvas in sync when the parent card is resized. */
@@ -183,6 +184,7 @@ if(data){
       scales: {
         x: {
             ticks: {
+                display: !chartPreviewMode,
                 font: {
                     family: 'Nunito',
                     size: fontSizeX,
@@ -219,7 +221,12 @@ if(data){
     const updatedBaseSets = cohortData.filter(cohort => cohort && cohort.cohortName).map((cohort) => {
       const seenValues = new Set();
       return {
-        label: buildVennCohortSetLabel(cohort.cohortName, cohort.participants.length),
+        label: buildVennCohortSetLabel(
+          cohort.cohortName,
+          cohort.participants.length,
+          undefined,
+          !chartPreviewMode,
+        ),
         values: cohort.participants
           .map(p => p[nodes[intersection]])
           .filter(value => {
@@ -234,7 +241,7 @@ if(data){
     });
 
     setBaseSets(updatedBaseSets);
-  }, [cohortData, intersection]);
+  }, [cohortData, intersection, chartPreviewMode]);
 
   useEffect(() => {
     if (baseSets.length > 0) {
@@ -296,7 +303,7 @@ useEffect(() => {
   return () => {
     if (chartRef.current) chartRef.current.destroy();
   };
-}, [selectedCohortSection, data, selectedCohort, cohortData, slotWidth, slotHeight, expandedView, observedPlotSize, viewportWidth]);
+}, [selectedCohortSection, data, selectedCohort, cohortData, slotWidth, slotHeight, expandedView, chartPreviewMode, observedPlotSize, viewportWidth]);
 
   useEffect(() => {
     let updatedStat = {};

--- a/src/pages/CohortAnalyzer/vennDiagram/ChartVennConfig.js
+++ b/src/pages/CohortAnalyzer/vennDiagram/ChartVennConfig.js
@@ -92,12 +92,16 @@ export function buildVennCohortSetLabel(
   cohortName,
   participantCount,
   maxNameChars = VENN_COHORT_NAME_MAX_CHARS,
+  includeCount = true,
 ) {
   const name = String(cohortName || '').trim();
   const cap = Number.isFinite(maxNameChars) && maxNameChars < name.length
     ? maxNameChars
     : name.length;
   const shortName = name.length > cap ? `${name.slice(0, cap)}…` : name;
+  if (!includeCount) {
+    return shortName;
+  }
   return `${shortName} (${participantCount})`;
 }
 

--- a/src/pages/CohortAnalyzer/vennDiagram/VennDiagramContainer.js
+++ b/src/pages/CohortAnalyzer/vennDiagram/VennDiagramContainer.js
@@ -12,10 +12,12 @@ import {
   defaultVennOuterPx,
   vennChartSlotDimensionsFromOuterPx,
 } from '../config/cohortAnalyzerViewPercentDefaults';
+import { buildPlaceholderVennCohortData } from '../utils/cohortAnalyzerChartPreview';
 
 const VennDiagramContainer = ({
   classes,
   state,
+  chartPreviewMode = false,
   containerRef,
   canvasRef,
   besideCardDrag,
@@ -42,12 +44,15 @@ const VennDiagramContainer = ({
   } = useCohortAnalyzer();
 
   const mappedCohortData = useMemo(() => {
-    if (cohortData && selectedCohorts.length > 0 && state) {
+    if (chartPreviewMode) {
+      return buildPlaceholderVennCohortData();
+    }
+    if (selectedCohorts.length > 0 && state) {
       const mappingFunction = (cohortId) => (cohortData || state)[cohortId];
       return selectedCohorts.map(mappingFunction);
     }
     return [];
-  }, [cohortData, selectedCohorts, state]);
+  }, [chartPreviewMode, cohortData, selectedCohorts, state]);
 
   const vennHasRenderableCohorts = useMemo(
     () => mappedCohortData.some(
@@ -58,19 +63,25 @@ const VennDiagramContainer = ({
 
   const chartModalVennActive = chartModalOpen && chartModalActiveTab === CA_EXPANDED_CHART_MODAL_TAB_VENN;
 
-  const showChartVenn = refreshTableContent
-    && selectedCohorts.length > 0
-    && vennHasRenderableCohorts
-    && !chartModalVennActive;
+  const showChartVenn = chartPreviewMode
+    ? refreshTableContent && !chartModalVennActive
+    : (
+      refreshTableContent
+      && selectedCohorts.length > 0
+      && vennHasRenderableCohorts
+      && !chartModalVennActive
+    );
 
-  const showVennEmptyState = selectedCohorts.length === 0
+  const showVennEmptyState = !chartPreviewMode && (
+    selectedCohorts.length === 0
     || (
       refreshTableContent
       && !chartModalVennActive
       && selectedCohorts.length > 0
       && cohortData != null
       && !vennHasRenderableCohorts
-    );
+    )
+  );
 
   const [vennContainerSize, setVennContainerSize] = useState(() =>
     (vennSizeFromStore != null ? vennSizeFromStore : defaultVennOuterPx()),
@@ -152,7 +163,7 @@ const VennDiagramContainer = ({
         setSelectedCohortSections(data);
       },
       selectedCohortSection,
-      selectedCohort: selectedCohorts,
+      selectedCohort: chartPreviewMode ? [] : selectedCohorts,
       setGeneralInfo,
     }),
     [
@@ -160,6 +171,7 @@ const VennDiagramContainer = ({
       mappedCohortData,
       handleSetSelectedChart,
       selectedCohortSection,
+      chartPreviewMode,
       selectedCohorts,
       setGeneralInfo,
       setSelectedCohortSections,
@@ -216,6 +228,7 @@ const VennDiagramContainer = ({
         {showChartVenn && (
           <ChartVenn
             {...chartVennProps}
+            chartPreviewMode={chartPreviewMode}
             containerRef={containerRef}
             canvasRef={canvasRef}
             slotWidth={chartSlot.slotWidth}


### PR DESCRIPTION
### Overview
When no cohort with participants is selected, the Cohort Analyzer chart area now shows a grayed-out preview instead of blank “No data” placeholders. Charts use placeholder labels (Cohort A / B / C) and empty shells—no example cohort data is loaded or shown as selected in the sidebar.

### Change Details (Specifics)
According the Previous design, the Histograms have greyed out charts.
Added cohortAnalyzerChartPreview.js with shared preview styling, placeholder cohort labels, empty Venn cohort data, risk-table month columns, and interaction-disable helpers.
Chart area: Preview opacity/grayscale applies only to the chart block (Venn, survival, histograms); Add Chart footer stays outside so both top and bottom buttons match color (#006A8F) and show the same disabled-state tooltips.
Venn: Renders an empty 3-set diagram with Cohort A/B/C labels only (no counts or inner 0 values) via chartPreviewMode on ChartVenn.
Survival: Empty KM plot and risk table with standard month headers (0–36 Months) and placeholder cohort rows.
Histograms: Skip API fetch in preview; show empty chart shells (axes/grid) with preview styling on each card; no real chart data.
Histogram/survival interactions (drag, resize, expand, download) remain disabled until a cohort is selected.
