### PR TITLE
C3DC 2192

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ You will also see any lint errors in the console.
 
 ### `npm test`
 
-Launches the test runner in the interactive watch mode.<br>
+Runs the test suite once (non-interactive, `--watchAll=false`) and exits.<br>
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+
+### `npm run test:watch`
+
+Launches the test runner in interactive watch mode (the prior behavior of `npm test`).<br>
+Use this during development to automatically re-run tests on file changes.
 
 ### `npm run build`
 

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -8,7 +8,6 @@ const { format } = require('util');
 const SUPPRESSED = [
   /createMuiTheme function was renamed to createTheme/i,
   /React Router Future Flag Warning/i,
-  /unique "key" prop/i,
   /Invalid DOM property.*stroke-dasharray/i,
   /CustomBreadcrumb/i,
 ];

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -1,0 +1,42 @@
+/**
+ * Suppress known third-party / DOM noise in Jest output (no package upgrades required).
+ * Patches after Jest installs its console buffer so filtered messages never appear in output.
+ */
+
+const { format } = require('util');
+
+const SUPPRESSED = [
+  /createMuiTheme function was renamed to createTheme/i,
+  /React Router Future Flag Warning/i,
+  /unique "key" prop/i,
+  /Invalid DOM property.*stroke-dasharray/i,
+  /CustomBreadcrumb/i,
+];
+
+function shouldSuppress(args) {
+  const text = format(...args);
+  return SUPPRESSED.some((pattern) => pattern.test(text));
+}
+
+function installConsoleFilters() {
+  const errorSink = console.error;
+  const warnSink = console.warn;
+
+  console.error = (...args) => {
+    if (shouldSuppress(args)) return;
+    errorSink(...args);
+  };
+
+  console.warn = (...args) => {
+    if (shouldSuppress(args)) return;
+    warnSink(...args);
+  };
+}
+
+// Re-apply after Jest's jsdom environment replaces console (once per worker).
+installConsoleFilters();
+
+// Some suites re-bind console when loading heavy UI; filter again before each file.
+beforeAll(() => {
+  installConsoleFilters();
+});

--- a/package.json
+++ b/package.json
@@ -88,8 +88,10 @@
   "scripts": {
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js",
-    "test:ci": "TZ=UTC node scripts/test.js --ci --passWithNoTests --coverage --maxWorkers=2 --logHeapUsage",
+    "test": "node scripts/test.js --watchAll=false --silent",
+    "test:watch": "node scripts/test.js",
+    "test:ci": "TZ=UTC node scripts/test.js --ci --passWithNoTests --coverage --maxWorkers=2 --logHeapUsage --silent",
+    "test:cohort-analyzer": "TZ=UTC node scripts/test.js --testPathPattern=src/pages/CohortAnalyzer/__tests__ --coverage --collectCoverageFrom=src/pages/CohortAnalyzer/**/*.{js,jsx} --collectCoverageFrom=!src/pages/CohortAnalyzer/**/*.styled.js --collectCoverageFrom=!src/pages/CohortAnalyzer/**/styles/** --watchAll=false --silent",
     "lint": "eslint src --max-warnings=0",
     "lint:ci": "eslint src --ignore-path .gitignore --max-warnings=0",
     "lint:fix": "eslint src --fix"
@@ -111,8 +113,11 @@
     "setupFiles": [
       "react-app-polyfill/jsdom"
     ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/config/jest/setupTests.js"
+    ],
     "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
+      "<rootDir>/src/**/__tests__/**/*.test.{js,jsx,ts,tsx}",
       "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}"
     ],
     "testEnvironment": "jsdom",

--- a/src/pages/CohortAnalyzer/CohortAnalyzer.js
+++ b/src/pages/CohortAnalyzer/CohortAnalyzer.js
@@ -33,6 +33,15 @@ import { getJoinedCohortData } from "./CohortAnalyzerUtil/CohortDataTransform";
 import { exampleCohorts, getExampleCohortKeys } from "../../bento/exampleCohortData";
 import { useUserGuide } from '../inventory/sideBar/UserGuideContext';
 import { USER_GUIDE_SECTION_ANALYZING_COHORTS } from '../inventory/sideBar/userGuideConstants';
+import {
+    computeHasParticipantData,
+    getCohortAnalyzerTableMessage,
+    filterVennSectionsForSelectedCohorts,
+    shouldClearRowDataOnEmptySelection,
+    canAddExampleCohorts,
+    buildExploreUploadPayload,
+    shouldSkipNavigateAwayModal,
+} from './cohortAnalyzerPageLogic';
 
 export const CohortAnalyzer = () => {
     const { openUserGuide } = useUserGuide();
@@ -76,12 +85,10 @@ export const CohortAnalyzer = () => {
     const canvasRef = useRef(null);
     const classes = useStyle();
     const { state, dispatch: cohortDispatch } = useContext(CohortStateContext);
-    const hasParticipantData = useMemo(() => {
-        if (!state || !Array.isArray(selectedCohorts)) return false;
-        return selectedCohorts.some(
-            (id) => state[id] && Array.isArray(state[id].participants) && state[id].participants.length > 0,
-        );
-    }, [state, selectedCohorts]);
+    const hasParticipantData = useMemo(
+        () => computeHasParticipantData(state, selectedCohorts),
+        [state, selectedCohorts],
+    );
     const { setShowCohortModal, showCohortModal, setCurrentCohortChanges, setWarningMessage, warningMessage } = useContext(CohortModalContext);
     const { Notification } = useGlobal();
     const navigate = useNavigate();
@@ -91,13 +98,7 @@ export const CohortAnalyzer = () => {
         // store.dispatch(updateAutocompleteData(data));
         // navigate('/explore');
 
-        const upload = rowData.map(r => ({ participant_id: r.participant_id, study_id: r.dbgap_accession }));
-        const uploadMetadata = {
-            filename: "",
-            fileContent: upload.map(p => p.participant_id).join(","),
-            matched: upload,
-            unmatched: [],
-        };
+        const { upload, uploadMetadata } = buildExploreUploadPayload(rowData);
 
         store.dispatch(updateUploadData(upload));
         store.dispatch(updateUploadMetadata(uploadMetadata));
@@ -105,8 +106,7 @@ export const CohortAnalyzer = () => {
     }
 
     const handleBuildInExplore = () => {
-        const hideModal = localStorage.getItem('hideNavigateModal') === 'true';
-        if (hideModal) {
+        if (shouldSkipNavigateAwayModal()) {
             handleUserRedirect(); // skip modal
         } else {
             setShowNavigateAwayModal(true); // show modal
@@ -183,47 +183,19 @@ export const CohortAnalyzer = () => {
         }
 
 
-        if (nodeIndex === 0 || nodeIndex === 1 || nodeIndex === 2) {
-            let finalVennSelection = [];
-            selectedCohortSection.forEach((section) => {
-                if (section.split(" ∩ ").length > 1) {
-                    let validCohorts = [];
-                    section.split(" ∩ ").forEach((sec, index) => {
-                        const regex = /(.*?)(?= \(\d+\))/;
-                        const match = sec.match(regex);
-                        if (selectedCohorts.includes(match[1])) {
-                            validCohorts.push(sec);
-                        }
-                    })
-
-                    if (validCohorts.length > 0) {
-                        finalVennSelection.push(validCohorts.join(" ∩ "))
-                    }
-                } else {
-                    const regex = /(.*?)(?= \(\d+\))/;
-                    const match = section.match(regex);
-                    if (match) {
-                        if (selectedCohorts.includes(match[1])) {
-                            finalVennSelection.push(section)
-                        }
-                    }
-
-                }
-
-            })
-            setSelectedCohortSections(finalVennSelection);
-
-        }
-
+        setSelectedCohortSections(
+            filterVennSectionsForSelectedCohorts(
+                selectedCohortSection,
+                selectedCohorts,
+                nodeIndex,
+            ),
+        );
 
         if (selectedCohorts.length === 0) {
             setGeneralInfo({});
-            if (location && location.state && location.state.cohort && location.state.cohort.cohortId) {
-
-            } else {
+            if (shouldClearRowDataOnEmptySelection(selectedCohorts, location)) {
                 setRowData([]);
             }
-
         }
     }, [selectedCohorts, selectedChart]);
 
@@ -287,8 +259,7 @@ export const CohortAnalyzer = () => {
 
         // Check if adding 3 example cohorts would exceed the 20-cohort limit
         // Only count non-example cohorts since example cohorts will be cleared/replaced
-        const nonExampleCohorts = Object.keys(state).filter(key => !exampleCohortKeys.includes(key));
-        if (nonExampleCohorts.length > 17) {
+        if (!canAddExampleCohorts(state, exampleCohortKeys)) {
             Notification.show('Cannot add example cohorts. You have reached the maximum limit of 20 cohorts. Please delete some cohorts first.', 5000);
             return;
         }
@@ -322,16 +293,6 @@ export const CohortAnalyzer = () => {
         });
     };
 
-    const getTableMessage = (cohortList, selectedCohortSection, tableConfig) => {
-        if (cohortList.length === 0) {
-            return { noMatch: 'To proceed, please create your cohort by visiting the Explore Page.' };
-        }
-        if (selectedCohortSection.length === 0) {
-            return tableConfig.tableMsg;
-        }
-        return { noMatch: "No data available for the selected segment/segments. Please try a different segment/segments." };
-    };
-
     const initTblState = (initailState) => ({
         ...initailState,
         title: analyzer_tables[nodeIndex].name,
@@ -361,7 +322,7 @@ export const CohortAnalyzer = () => {
         downloadFileName: "download",
         SearchBox: () => SearchBox(classes, handleSearchValue, searchValue, searchRef),
         showSearchBox: true,
-        tableMsg: getTableMessage(cohortList, selectedCohortSection, tableConfig)
+        tableMsg: getCohortAnalyzerTableMessage(cohortList, selectedCohortSection, tableConfig)
     });
 
     const besideDnD = useBesidePanelDnD(survivalBesideColumnActive);

--- a/src/pages/CohortAnalyzer/CohortSelector/cohortSelectorStyling.js
+++ b/src/pages/CohortAnalyzer/CohortSelector/cohortSelectorStyling.js
@@ -7,8 +7,8 @@ export const useStyle = makeStyles((theme) => ({
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'stretch',
-        minWidth: 268,
-        maxWidth: 268,
+        minWidth: 274,
+        maxWidth: 274,
         flexShrink: 0,
     },
     sortCount: {
@@ -20,7 +20,7 @@ export const useStyle = makeStyles((theme) => ({
     },
     leftSideAnalyzer: {
         width: '100%',
-        height: 588,
+        height: 400,
         marginTop: 40,
         overflow: 'hidden',
         borderRadius: ' 0px 35px 35px 0px',
@@ -182,7 +182,7 @@ export const useStyle = makeStyles((theme) => ({
         textAlign: 'left',
         width: '100%',
         display: 'flex',
-        paddingTop: 16,
+        paddingTop: 32,
         flexDirection: 'column',
         alignSelf: 'center',
         margin: 'auto',
@@ -205,9 +205,11 @@ export const useStyle = makeStyles((theme) => ({
     sortSection: {
         height: 31,
         width: '100%',
+        boxSizing: 'border-box',
         display: 'flex',
         justifyContent: 'space-between',
-        marginLeft: 20,
+        paddingLeft: 20,
+        backgroundColor: '#F1F1F1',
         '& p': {
             fontSize: 9
         }

--- a/src/pages/CohortAnalyzer/__tests__/README.md
+++ b/src/pages/CohortAnalyzer/__tests__/README.md
@@ -1,0 +1,59 @@
+# Cohort Analyzer tests
+
+Jest tests for the Cohort Analyzer module. Layout mirrors feature areas so new coverage is easy to add.
+
+## Structure
+
+```
+__tests__/
+  ../testSupport/       # Shared mocks and render helpers (outside __tests__ so Jest does not run them as suites)
+  test-entry-point/     # CohortAnalyzer.js page shell: handlers, effects, wiring (mocked children)
+  unit/                 # Pure functions, reducers, hooks utilities
+    utils/
+    store/
+    config/
+    vennDiagram/
+    components/
+    CohortAnalyzerUtil/
+    HistogramPanel/
+    downloads/
+    controllers/
+    customCheckbox/
+    styling/
+    CreateNewCohortButton/
+    CohortAnalyzerTableSection/
+
+**30 test suites** total under `__tests__/`.
+```
+
+## Commands
+
+```bash
+# All Cohort Analyzer tests with coverage (quiet output — no known third-party console noise)
+npm run test:cohort-analyzer
+
+# Watch mode (full project test runner)
+npm run test:watch -- --testPathPattern=CohortAnalyzer/__tests__
+```
+
+Test runs use Jest `--silent` plus `config/jest/setupTests.js` so Material-UI, React Router, and similar warnings are not printed. Unexpected errors still fail tests.
+
+## Adding tests
+
+1. **Pure logic** — add `unit/<area>/<module>.test.js` and import the function directly.
+2. **Page logic** — prefer `cohortAnalyzerPageLogic.js` for testable branches from `CohortAnalyzer.js`.
+3. **Page entry point** — add or extend `test-entry-point/` with mocks in `testSupport/cohortAnalyzerMocks.js` (wiring and effects on `CohortAnalyzer.js`, not child UI).
+4. **Redux** — test reducers/actions under `unit/store/`.
+
+## Coverage goals
+
+| Area | Target | Status |
+|------|--------|--------|
+| `cohortAnalyzerPageLogic.js` | 100% functions | Covered |
+| `utils/cohortAnalyzerChartPreview.js` | 100% | Covered |
+| `CohortAnalyzerUtil.js` | 100% statements | Covered |
+| `store/` actions, reducers, DnD helpers | High / 100% functions | Covered |
+| `CohortAnalyzer.js` | Page handlers + effects | ~94% lines (`test-entry-point/`) |
+| Large UI (Histogram, ChartVenn, ChartArea) | On change | Add `unit/` or `test-entry-point/` per feature |
+
+Run `npm run test:cohort-analyzer` for the full report.

--- a/src/pages/CohortAnalyzer/__tests__/test-entry-point/CohortAnalyzer.entryPoint.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/test-entry-point/CohortAnalyzer.entryPoint.test.js
@@ -1,0 +1,472 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  mockNavigate,
+  mockDispatch,
+  mockNotificationShow,
+  mockGetJoinedCohortData,
+  mockOpenUserGuide,
+  defaultCohortAnalyzerContext,
+  defaultCohortState,
+  resetCohortAnalyzerMocks,
+} from '../../testSupport/cohortAnalyzerMocks';
+import { renderWithCohortAnalyzerProviders } from '../../testSupport/cohortAnalyzerTestUtils';
+
+const mockUseCohortAnalyzer = jest.fn(() => defaultCohortAnalyzerContext);
+let mockLocation = { state: null };
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockLocation,
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector) => selector({
+    cohortAnalyzerLayout: { topRowOrder: ['venn', 'survival'] },
+  }),
+}));
+
+jest.mock('../../context/CohortAnalyzerContext', () => ({
+  useCohortAnalyzer: () => mockUseCohortAnalyzer(),
+}));
+
+jest.mock('../../../../components/CohortSelectorState/CohortStateContext', () => {
+  const ReactMock = require('react');
+  return {
+    CohortStateContext: ReactMock.createContext({
+      state: {},
+      dispatch: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../../../components/CohortModal/CohortModalContext', () => {
+  const ReactMock = require('react');
+  return {
+    CohortModalContext: ReactMock.createContext({
+      setShowCohortModal: jest.fn(),
+      showCohortModal: false,
+      setCurrentCohortChanges: jest.fn(),
+      setWarningMessage: jest.fn(),
+      warningMessage: '',
+    }),
+  };
+});
+
+jest.mock('../../../../components/Global/GlobalProvider', () => ({
+  useGlobal: () => ({ Notification: { show: mockNotificationShow } }),
+}));
+
+jest.mock('../../CohortAnalyzerUtil/CohortDataTransform', () => ({
+  getJoinedCohortData: (...args) => mockGetJoinedCohortData(...args),
+}));
+
+jest.mock('../../../../components/Stats/GlobalStatsController', () => () => <div data-testid="stats" />);
+jest.mock('../../components/navigateAwayModal', () => () => null);
+jest.mock('../../../../components/CohortModal/components/shared/ConfirmationModal', () => ({
+  __esModule: true,
+  default: ({ open, setOpen, handleConfirm, message }) => (
+    open ? (
+      <div data-testid="confirmation-modal">
+        {message ? <span>{message}</span> : null}
+        <button type="button" onClick={setOpen}>Close confirmation</button>
+        <button type="button" onClick={handleConfirm}>Confirm action</button>
+      </div>
+    ) : null
+  ),
+}));
+jest.mock('../../../../components/CohortModal/CohortModal', () => ({
+  __esModule: true,
+  default: ({ open, onCloseModal }) => (
+    open ? (
+      <button type="button" onClick={onCloseModal}>Close cohort modal</button>
+    ) : null
+  ),
+}));
+jest.mock('../../CohortSelector/CohortSelector', () => ({
+  CohortSelector: ({ handleDemoClick }) => (
+    <button type="button" onClick={handleDemoClick}>Demo</button>
+  ),
+}));
+jest.mock('../../components/CohortAnalyzerSummaryView', () => ({
+  CohortAnalyzerSummaryView: ({ chartPanel, tablePanel, summaryTrailingActions }) => (
+    <div>
+      {summaryTrailingActions}
+      {chartPanel}
+      {tablePanel}
+    </div>
+  ),
+}));
+jest.mock('../../components/CohortAnalyzerChartArea', () => ({
+  CohortAnalyzerChartArea: () => <div data-testid="chart-area" />,
+}));
+jest.mock('../../CohortAnalyzerTableSection/CohortAnalyzerTableSection', () => ({
+  CohortAnalyzerTableSection: ({ handleBuildInExplore, handleClick, initTblState }) => {
+    const tblState = initTblState({});
+    const SearchBoxComponent = tblState.SearchBox;
+    return (
+      <div data-testid="table-section">
+        <SearchBoxComponent />
+        <button type="button" onClick={handleBuildInExplore}>Build in Explore</button>
+        <button type="button" onClick={handleClick}>Create cohort</button>
+      </div>
+    );
+  },
+}));
+jest.mock('../../hooks/useBesidePanelDnD', () => ({
+  useBesidePanelDnD: () => ({
+    survivalBesideTopRowUsesOrder: false,
+    besideDropTarget: null,
+    besideColumnDropTargetStyle: {},
+    handleBesideRowDragLeave: jest.fn(),
+    handleBesideColumnDragOver: () => jest.fn(),
+    handleBesidePanelDrop: () => jest.fn(),
+    survivalBesideDrag: {},
+    besidePanelDragging: null,
+    besidePanelDraggingRef: { current: null },
+    endBesidePanelDrag: jest.fn(),
+  }),
+}));
+
+jest.mock('../../styling/cohortAnalyzerStyling', () => ({
+  useStyle: () => ({
+    container: 'container',
+    rightSideAnalyzer: 'right',
+    alert: 'alert',
+    rightSideAnalyzerHeader: 'header',
+    readmeButton: 'readme',
+  }),
+}));
+
+jest.mock('../../../inventory/sideBar/UserGuideContext', () => ({
+  useUserGuide: () => ({ openUserGuide: mockOpenUserGuide }),
+}));
+
+const mockStoreDispatch = jest.fn();
+jest.mock('../../../../store', () => ({
+  __esModule: true,
+  default: { dispatch: (...args) => mockStoreDispatch(...args) },
+}));
+
+jest.mock('../../../../bento/exampleCohortData', () => ({
+  exampleCohorts: [{ cohortId: 'Ex 1', cohortDescription: 'd', participants: [] }],
+  getExampleCohortKeys: () => ['ex 1'],
+}));
+
+jest.mock('../../../../components/CohortSelectorState/store/action', () => ({
+  onCreateNewCohort: jest.fn((id, desc, parts, onSuccess) => {
+    if (onSuccess) onSuccess(1);
+    return { type: 'MOCK_CREATE' };
+  }),
+  onDeleteSingleCohort: jest.fn(() => ({ type: 'MOCK_DELETE' })),
+  onDeleteAllCohort: jest.fn(() => ({ type: 'MOCK_DELETE_ALL' })),
+}));
+
+import { CohortStateContext } from '../../../../components/CohortSelectorState/CohortStateContext';
+import { CohortModalContext } from '../../../../components/CohortModal/CohortModalContext';
+import { CohortAnalyzer } from '../../CohortAnalyzer';
+
+describe('CohortAnalyzer page entry point', () => {
+  const modalContext = {
+    setShowCohortModal: jest.fn(),
+    showCohortModal: false,
+    setCurrentCohortChanges: jest.fn(),
+    setWarningMessage: jest.fn(),
+    warningMessage: '',
+  };
+
+  const renderPage = (contextOverrides = {}, state = defaultCohortState, modalOverrides = {}) => {
+    mockUseCohortAnalyzer.mockReturnValue({ ...defaultCohortAnalyzerContext, ...contextOverrides });
+    return renderWithCohortAnalyzerProviders(
+      <CohortStateContext.Provider value={{ state, dispatch: mockDispatch }}>
+        <CohortModalContext.Provider value={{ ...modalContext, ...modalOverrides }}>
+          <CohortAnalyzer />
+        </CohortModalContext.Provider>
+      </CohortStateContext.Provider>,
+    );
+  };
+
+  beforeEach(() => {
+    resetCohortAnalyzerMocks();
+    mockStoreDispatch.mockClear();
+    mockLocation = { state: null };
+    jest.useFakeTimers();
+    localStorage.clear();
+    const { onCreateNewCohort } = require('../../../../components/CohortSelectorState/store/action');
+    onCreateNewCohort.mockImplementation((id, desc, parts, onSuccess) => {
+      if (onSuccess) onSuccess(1);
+      return { type: 'MOCK_CREATE' };
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders page title and main sections', () => {
+    renderPage();
+    expect(screen.getByText('Cohort Analyzer')).toBeInTheDocument();
+    expect(screen.getByTestId('chart-area')).toBeInTheDocument();
+    expect(screen.getByTestId('table-section')).toBeInTheDocument();
+  });
+
+  it('opens user guide from README button', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /readme/i }));
+    expect(mockOpenUserGuide).toHaveBeenCalled();
+  });
+
+  it('shows alert and clears it after timeout', () => {
+    renderPage({ alert: { type: 'success', message: 'Saved' } });
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(2600);
+    });
+    expect(defaultCohortAnalyzerContext.setAlert).toHaveBeenCalledWith({ type: '', message: '' });
+  });
+
+  it('calls getJoinedCohortData when selected cohorts change', () => {
+    renderPage({ selectedCohorts: ['cohort-a'], selectedChart: [] });
+    expect(mockGetJoinedCohortData).toHaveBeenCalled();
+  });
+
+  it('handleDemoClick blocks when cohort limit exceeded', () => {
+    const manyCohorts = {};
+    for (let i = 0; i < 18; i += 1) {
+      manyCohorts[`c${i}`] = { participants: [] };
+    }
+    renderPage({}, manyCohorts);
+    fireEvent.click(screen.getByText('Demo'));
+    expect(mockNotificationShow).toHaveBeenCalledWith(
+      expect.stringContaining('maximum limit'),
+      5000,
+    );
+  });
+
+  it('handleDemoClick creates example cohorts when under limit', () => {
+    renderPage({}, {});
+    fireEvent.click(screen.getByText('Demo'));
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('computes hasParticipantData when cohort has participants', () => {
+    renderPage({ selectedCohorts: ['cohort-a'] }, defaultCohortState);
+    expect(mockUseCohortAnalyzer).toHaveBeenCalled();
+  });
+
+  it('selects cohort from location state on mount', () => {
+    const handleCheckbox = jest.fn();
+    mockLocation = { state: { cohort: { cohortId: 'nav-cohort' } } };
+    renderPage({ handleCheckbox });
+    expect(handleCheckbox).toHaveBeenCalledWith('nav-cohort', null);
+  });
+
+  it('filters venn sections when nodeIndex is valid', () => {
+    renderPage({
+      nodeIndex: 0,
+      selectedCohortSection: ['Cohort A (1)'],
+      selectedCohorts: ['Cohort A'],
+    });
+    expect(defaultCohortAnalyzerContext.setSelectedCohortSections).toHaveBeenCalledWith(['Cohort A (1)']);
+  });
+
+  it('clears row data when selection empty without navigation cohort', () => {
+    renderPage({ selectedCohorts: [], selectedChart: [] });
+    expect(defaultCohortAnalyzerContext.setRowData).toHaveBeenCalledWith([]);
+  });
+
+  it('handleBuildInExplore skips modal when localStorage flag is set', () => {
+    localStorage.setItem('hideNavigateModal', 'true');
+    renderPage({
+      rowData: [{ participant_id: 'P1', dbgap_accession: 'phs1' }],
+    });
+    fireEvent.click(screen.getByRole('button', { name: /build in explore/i }));
+    expect(mockStoreDispatch).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/explore');
+    expect(defaultCohortAnalyzerContext.setShowNavigateAwayModal).not.toHaveBeenCalled();
+  });
+
+  it('handleBuildInExplore opens navigate-away modal by default', () => {
+    renderPage({ rowData: [{ participant_id: 'P1', dbgap_accession: 'phs1' }] });
+    fireEvent.click(screen.getByRole('button', { name: /build in explore/i }));
+    expect(defaultCohortAnalyzerContext.setShowNavigateAwayModal).toHaveBeenCalledWith(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('handleClick creates cohort when section and row data exist', () => {
+    renderPage({
+      selectedCohortSection: ['Cohort A (1)'],
+      rowData: [{ participant_id: 'P1' }],
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create cohort/i }));
+    expect(mockDispatch).toHaveBeenCalled();
+    expect(modalContext.setShowCohortModal).toHaveBeenCalledWith(true);
+  });
+
+  it('handleClick does nothing without section or row data', () => {
+    renderPage({ selectedCohortSection: [], rowData: [] });
+    fireEvent.click(screen.getByRole('button', { name: /create cohort/i }));
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('clears search when selectedChart changes', () => {
+    const { rerender } = renderPage({ selectedChart: ['race'] });
+    mockUseCohortAnalyzer.mockReturnValue({
+      ...defaultCohortAnalyzerContext,
+      selectedChart: ['sexAtBirth'],
+    });
+    rerender(
+      <CohortStateContext.Provider value={{ state: defaultCohortState, dispatch: mockDispatch }}>
+        <CohortModalContext.Provider value={modalContext}>
+          <CohortAnalyzer />
+        </CohortModalContext.Provider>
+      </CohortStateContext.Provider>,
+    );
+    expect(defaultCohortAnalyzerContext.setSearchValue).toHaveBeenCalledWith('');
+  });
+
+  it('handleSearchValue updates search and focuses input when cleared', () => {
+    renderPage({ searchValue: 'abc' });
+    const input = screen.getByPlaceholderText('Search Participant ID');
+    fireEvent.change(input, { target: { value: '' } });
+    expect(defaultCohortAnalyzerContext.setSearchValue).toHaveBeenCalledWith('');
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+  });
+
+  it('dismisses alert via onClose', () => {
+    renderPage({ alert: { type: 'info', message: 'Note' } });
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(defaultCohortAnalyzerContext.setAlert).toHaveBeenCalledWith({ type: '', message: '' });
+  });
+
+  it('resets venn sections when nodeIndex changes', () => {
+    const { rerender } = renderPage({ nodeIndex: 0 });
+    mockUseCohortAnalyzer.mockReturnValue({
+      ...defaultCohortAnalyzerContext,
+      nodeIndex: 1,
+    });
+    rerender(
+      <CohortStateContext.Provider value={{ state: defaultCohortState, dispatch: mockDispatch }}>
+        <CohortModalContext.Provider value={modalContext}>
+          <CohortAnalyzer />
+        </CohortModalContext.Provider>
+      </CohortStateContext.Provider>,
+    );
+    expect(defaultCohortAnalyzerContext.setSelectedCohortSections).toHaveBeenCalledWith([]);
+    expect(defaultCohortAnalyzerContext.setGeneralInfo).toHaveBeenCalledWith({});
+  });
+
+  it('handleClick surfaces create-cohort errors', () => {
+    const { onCreateNewCohort } = require('../../../../components/CohortSelectorState/store/action');
+    onCreateNewCohort.mockImplementationOnce((id, desc, parts, onSuccess, onError) => {
+      onError(new Error('duplicate'));
+    });
+    renderPage({
+      selectedCohortSection: ['Cohort A (1)'],
+      rowData: [{ participant_id: 'P1' }],
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create cohort/i }));
+    expect(modalContext.setWarningMessage).toHaveBeenCalledWith(' duplicate');
+  });
+
+  it('handleDemoClick shows error when example cohort creation fails', () => {
+    const { onCreateNewCohort } = require('../../../../components/CohortSelectorState/store/action');
+    onCreateNewCohort.mockImplementationOnce((id, desc, parts, onSuccess, onError) => {
+      if (onError) onError(new Error('create failed'));
+      return { type: 'MOCK_CREATE_FAIL' };
+    });
+    renderPage({}, {});
+    fireEvent.click(screen.getByText('Demo'));
+    expect(mockNotificationShow).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to create example cohorts'),
+      5000,
+    );
+  });
+
+  it('does not clear row data when empty selection but navigation cohort present', () => {
+    mockLocation = { state: { cohort: { cohortId: 'nav-cohort' } } };
+    defaultCohortAnalyzerContext.setRowData.mockClear();
+    renderPage({ selectedCohorts: [], selectedChart: [] });
+    expect(defaultCohortAnalyzerContext.setRowData).not.toHaveBeenCalledWith([]);
+  });
+
+  it('confirms cohort deletion from confirmation modal', () => {
+    renderPage({
+      deleteInfo: {
+        showDeleteConfirmation: true,
+        deleteType: 'delete this cohort?',
+        cohortId: 'cohort-a',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /confirm action/i }));
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('dismisses warning confirmation modal', () => {
+    renderPage({}, defaultCohortState, { warningMessage: 'Something went wrong' });
+    fireEvent.click(screen.getByRole('button', { name: /close confirmation/i }));
+    expect(modalContext.setWarningMessage).toHaveBeenCalledWith('');
+  });
+
+  it('confirms warning modal clears message', () => {
+    renderPage({}, defaultCohortState, { warningMessage: 'Something went wrong' });
+    fireEvent.click(screen.getByRole('button', { name: /confirm action/i }));
+    expect(modalContext.setWarningMessage).toHaveBeenCalledWith('');
+  });
+
+  it('closes cohort modal', () => {
+    renderPage({}, defaultCohortState, { showCohortModal: true });
+    fireEvent.click(screen.getByRole('button', { name: /close cohort modal/i }));
+    expect(modalContext.setShowCohortModal).toHaveBeenCalledWith(false);
+  });
+
+  it('handleDemoClick auto-selects example cohorts when all are created', () => {
+    renderPage({}, {});
+    fireEvent.click(screen.getByText('Demo'));
+    expect(defaultCohortAnalyzerContext.setSelectedCohorts).toHaveBeenCalled();
+    expect(mockNotificationShow).toHaveBeenCalledWith(
+      expect.stringContaining('Successfully created'),
+      7000,
+    );
+  });
+
+  it('toggles delete confirmation closed via setOpen', () => {
+    const setDeleteInfo = jest.fn();
+    renderPage({
+      deleteInfo: {
+        showDeleteConfirmation: true,
+        deleteType: 'delete this cohort?',
+        cohortId: 'cohort-a',
+      },
+      setDeleteInfo,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /close confirmation/i }));
+    expect(setDeleteInfo).toHaveBeenCalled();
+  });
+
+  it('refreshes table content when cohort list changes', () => {
+    const { rerender } = renderPage({ cohortList: ['a'] });
+    mockUseCohortAnalyzer.mockReturnValue({
+      ...defaultCohortAnalyzerContext,
+      cohortList: ['a', 'b'],
+    });
+    rerender(
+      <CohortStateContext.Provider value={{ state: defaultCohortState, dispatch: mockDispatch }}>
+        <CohortModalContext.Provider value={modalContext}>
+          <CohortAnalyzer />
+        </CohortModalContext.Provider>
+      </CohortStateContext.Provider>,
+    );
+    expect(defaultCohortAnalyzerContext.setRefreshTableContent).toHaveBeenCalledWith(false);
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(defaultCohortAnalyzerContext.setRefreshTableContent).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/CohortAnalyzerTableSection/ButtonWithTooltip.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/CohortAnalyzerTableSection/ButtonWithTooltip.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@bento-core/tool-tip/dist/ToolTip', () => ({
+  __esModule: true,
+  default: ({ title, children }) => (
+    <div data-testid="tooltip" title={typeof title === 'object' ? 'rich' : title}>
+      {children}
+    </div>
+  ),
+}));
+
+import { ButtonWithTooltip } from '../../../CohortAnalyzerTableSection/ButtonWithTooltip';
+
+describe('ButtonWithTooltip', () => {
+  it('invokes onClick when enabled', () => {
+    const onClick = jest.fn();
+    render(
+      <ButtonWithTooltip
+        className="btn"
+        disabled={false}
+        onClick={onClick}
+        tooltip="Help text"
+        icon="help.png"
+      >
+        Export
+      </ButtonWithTooltip>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('does not invoke onClick when disabled', () => {
+    const onClick = jest.fn();
+    render(
+      <ButtonWithTooltip
+        className="btn"
+        disabled
+        onClick={onClick}
+        tooltip="Help"
+        icon="help.png"
+      >
+        Export
+      </ButtonWithTooltip>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/CohortAnalyzerUtil/CohortAnalyzerUtil.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/CohortAnalyzerUtil/CohortAnalyzerUtil.test.js
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  triggerNotification,
+  filterAllParticipantWithDiagnosisName,
+  filterAllParticipantWithTreatmentType,
+  getIdsFromCohort,
+  getAllIds,
+  addCohortColumn,
+  resetSelection,
+  sortBy,
+  sortByReturn,
+  handleDelete,
+  SearchBox,
+  generateQueryVariable,
+  handlePopup,
+} from '../../../CohortAnalyzerUtil/CohortAnalyzerUtil';
+
+describe('CohortAnalyzerUtil', () => {
+  describe('triggerNotification', () => {
+    it('shows plural message for multiple participants', () => {
+      const Notification = { show: jest.fn() };
+      triggerNotification(2, Notification);
+      expect(Notification.show).toHaveBeenCalledWith(expect.stringContaining('Participants'), 5000);
+    });
+
+    it('shows singular message for one participant', () => {
+      const Notification = { show: jest.fn() };
+      triggerNotification(1, Notification);
+      expect(Notification.show).toHaveBeenCalledWith(expect.stringContaining('Participant added'), 5000);
+    });
+  });
+
+  describe('filterAllParticipantWithDiagnosisName', () => {
+    it('filters participants by diagnosis in generalInfo', () => {
+      const generalInfo = { section1: ['D1'] };
+      const participants = [
+        { diagnosis: 'D1', id: 1 },
+        { diagnosis: 'D2', id: 2 },
+      ];
+      const result = filterAllParticipantWithDiagnosisName(generalInfo, participants);
+      expect(result).toHaveLength(1);
+      expect(result[0].diagnosis).toBe('D1');
+    });
+  });
+
+  describe('filterAllParticipantWithTreatmentType', () => {
+    it('filters participants by treatment type', () => {
+      const generalInfo = { section1: ['Chemo'] };
+      const participants = [
+        { treatment_type: 'Chemo' },
+        { treatment_type: 'Radio' },
+      ];
+      expect(filterAllParticipantWithTreatmentType(generalInfo, participants)).toHaveLength(1);
+    });
+  });
+
+  describe('getIdsFromCohort', () => {
+    it('collects participant pks for selected cohorts', () => {
+      const data = {
+        a: { participants: [{ participant_pk: 'pk1' }, { participant_pk: 'pk2' }] },
+        b: { participants: [{ participant_pk: 'pk3' }] },
+      };
+      expect(getIdsFromCohort(data, ['a'])).toEqual(['pk1', 'pk2']);
+    });
+
+    it('skips cohorts without participants array', () => {
+      const data = { a: {}, b: { participants: [{ participant_pk: 'pk1' }] } };
+      expect(getIdsFromCohort(data, ['a', 'b'])).toEqual(['pk1']);
+    });
+  });
+
+  describe('getAllIds', () => {
+    it('flattens generalInfo sections', () => {
+      expect(getAllIds({ a: [1, 2], b: [3] })).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('addCohortColumn', () => {
+    const state = {
+      'cohort a': {
+        cohortName: 'Cohort A',
+        participants: [{ participant_pk: 'pk1' }],
+      },
+    };
+
+    it('adds cohort column using participant_pk', () => {
+      const rows = [{ participant_pk: 'pk1', value: 1 }];
+      const result = addCohortColumn(rows, state, ['cohort a'], 'other');
+      expect(result[0].cohort).toBeDefined();
+    });
+
+    it('adds cohort column using id for treatment type', () => {
+      const rows = [{ id: 'pk1', value: 1 }];
+      const result = addCohortColumn(rows, state, ['cohort a'], 'treatment');
+      expect(result[0].cohort).toBeDefined();
+    });
+  });
+
+  describe('resetSelection', () => {
+    it('clears cohorts, row data, and resets node index', () => {
+      const setSelectedCohorts = jest.fn();
+      const setNodeIndex = jest.fn();
+      const setRowData = jest.fn();
+      resetSelection(setSelectedCohorts, setNodeIndex, setRowData);
+      expect(setSelectedCohorts).toHaveBeenCalledWith([]);
+      expect(setRowData).toHaveBeenCalledWith([]);
+      expect(setNodeIndex).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('sortBy', () => {
+    it('sorts alphabetically', () => {
+      const setCohortList = jest.fn();
+      const result = sortBy('alphabet', ['b', 'a'], setCohortList, {});
+      expect(result).toEqual(['a', 'b']);
+    });
+
+    it('sorts by participant count', () => {
+      const state = { a: { participants: [1, 2] }, b: { participants: [1] } };
+      const result = sortBy('count', ['a', 'b'], jest.fn(), state);
+      expect(result[0]).toBe('b');
+    });
+  });
+
+  describe('sortByReturn', () => {
+    it('puts selected cohorts first when sorted alphabetically', () => {
+      const state = { a: { participants: [] }, b: { participants: [] }, c: { participants: [] } };
+      const result = sortByReturn('alphabet', ['c', 'b', 'a'], state, ['b']);
+      expect(result[0]).toBe('b');
+    });
+
+    it('sorts by participant count when type is not alphabet', () => {
+      const state = {
+        a: { participants: [1, 2] },
+        b: { participants: [1] },
+        c: { participants: [] },
+      };
+      const result = sortByReturn('count', ['a', 'b', 'c'], state, []);
+      expect(result[0]).toBe('c');
+    });
+  });
+
+  describe('handleDelete', () => {
+    it('deletes single cohort', () => {
+      const dispatch = jest.fn();
+      const setCohortList = jest.fn((fn) => fn(['a', 'b']));
+      const setSelectedCohorts = jest.fn((fn) => fn(['a']));
+      handleDelete('a', setCohortList, setSelectedCohorts, dispatch, jest.fn(), jest.fn(), jest.fn(), jest.fn());
+      expect(dispatch).toHaveBeenCalled();
+    });
+
+    it('deletes all cohorts when cohortId is falsy', () => {
+      const setCohortList = jest.fn();
+      const setSelectedCohorts = jest.fn();
+      const setGeneralInfo = jest.fn();
+      const setRowData = jest.fn();
+      handleDelete(null, setCohortList, setSelectedCohorts, jest.fn(), jest.fn(), jest.fn(), setGeneralInfo, setRowData);
+      expect(setCohortList).toHaveBeenCalledWith([]);
+      expect(setGeneralInfo).toHaveBeenCalledWith({});
+    });
+  });
+
+  describe('generateQueryVariable', () => {
+    it('builds participant_pk query from state', () => {
+      const state = { a: { participants: [{ participant_pk: 'pk1' }] } };
+      const query = generateQueryVariable(['a'], state);
+      expect(query.participant_pk).toEqual(['pk1']);
+      expect(query.first).toBe(10000);
+    });
+  });
+
+  describe('handlePopup', () => {
+    it('toggles delete confirmation when state has cohorts', () => {
+      const setDeleteInfo = jest.fn();
+      handlePopup('id1', { a: {} }, setDeleteInfo, { showDeleteConfirmation: false });
+      expect(setDeleteInfo).toHaveBeenCalledWith({
+        showDeleteConfirmation: true,
+        deleteType: 'delete this cohort?',
+        cohortId: 'id1',
+      });
+    });
+
+    it('does nothing when state is empty', () => {
+      const setDeleteInfo = jest.fn();
+      handlePopup('id1', {}, setDeleteInfo, {});
+      expect(setDeleteInfo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SearchBox', () => {
+    it('renders search input', () => {
+      const classes = { inputStyleContainer: 'c', inputStyle: 'i' };
+      const ref = { current: null };
+      render(SearchBox(classes, jest.fn(), '', ref));
+      expect(screen.getByPlaceholderText('Search Participant ID')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/CohortAnalyzerUtil/CohortDataTransform.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/CohortAnalyzerUtil/CohortDataTransform.test.js
@@ -1,0 +1,96 @@
+jest.mock('../../../../../utils/graphqlClient', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+jest.mock('../../../../../bento/cohortAnalyzerPageData', () => ({
+  analyzer_query: [{ query: 'PARTICIPANTS' }, { query: 'DIAGNOSIS' }, { query: 'TREATMENT' }],
+  responseKeys: ['participants', 'diagnosis', 'treatment'],
+}));
+
+import client from '../../../../../utils/graphqlClient';
+import { getJoinedCohortData } from '../../../CohortAnalyzerUtil/CohortDataTransform';
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('CohortDataTransform', () => {
+  const state = {
+    'cohort-a': {
+      cohortName: 'Cohort A',
+      participants: [{ participant_pk: 'pk1', participant: { id: 'pk1', participant_id: 'P1' } }],
+    },
+  };
+
+  beforeEach(() => {
+    client.query.mockReset();
+    client.query.mockResolvedValue({
+      data: {
+        participants: [
+          { id: 'pk1', participant_id: 'P1', participant: { id: 'pk1', participant_id: 'P1' } },
+        ],
+      },
+    });
+  });
+
+  it('fetches participant rows for nodeIndex 0', async () => {
+    const setRowData = jest.fn();
+    const setQueryVariable = jest.fn();
+    const setCohortData = jest.fn();
+
+    await getJoinedCohortData({
+      nodeIndex: 0,
+      selectedCohorts: ['cohort-a'],
+      state,
+      generalInfo: {},
+      searchValue: '',
+      setQueryVariable,
+      setRowData,
+      location: {},
+      setCohortData,
+    });
+    await flushPromises();
+
+    expect(client.query).toHaveBeenCalled();
+    expect(setQueryVariable).toHaveBeenCalled();
+    expect(setRowData).toHaveBeenCalled();
+  });
+
+  it('filters row data by search value', async () => {
+    const setRowData = jest.fn();
+
+    await getJoinedCohortData({
+      nodeIndex: 0,
+      selectedCohorts: ['cohort-a'],
+      state,
+      generalInfo: {},
+      searchValue: 'NO_MATCH',
+      setQueryVariable: jest.fn(),
+      setRowData,
+      location: {},
+      setCohortData: jest.fn(),
+    });
+    await flushPromises();
+
+    expect(setRowData).toHaveBeenCalledWith([]);
+  });
+
+  it('clears row data when no participant pks and no navigation cohort', async () => {
+    const setRowData = jest.fn();
+    client.query.mockResolvedValueOnce({ data: { participants: [] } });
+
+    await getJoinedCohortData({
+      nodeIndex: 0,
+      selectedCohorts: [],
+      state: {},
+      generalInfo: {},
+      searchValue: '',
+      setQueryVariable: jest.fn(),
+      setRowData,
+      location: {},
+      setCohortData: jest.fn(),
+    });
+    await flushPromises();
+
+    expect(setRowData).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/CreateNewCohortButton/CreateNewCohortButton.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/CreateNewCohortButton/CreateNewCohortButton.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@material-ui/core', () => ({
+  makeStyles: () => () => ({
+    createCohort: 'enabled',
+    createCohortOpacity: 'disabled',
+  }),
+}));
+
+jest.mock('@bento-core/tool-tip/dist/ToolTip', () => ({
+  __esModule: true,
+  default: ({ children }) => <div data-testid="tooltip">{children}</div>,
+}));
+
+import { CreateNewCohortButton } from '../../../CreateNewCohortButton/CreateNewCohortButton';
+
+describe('CreateNewCohortButton', () => {
+  it('calls handleClick when enabled', () => {
+    const handleClick = jest.fn();
+    render(
+      <CreateNewCohortButton
+        selectedCohortSection={['seg']}
+        rowData={[{ id: 1 }]}
+        questionIcon="icon.png"
+        handleClick={handleClick}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /create new cohort/i }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('still renders when section and row data are empty', () => {
+    render(
+      <CreateNewCohortButton
+        selectedCohortSection={[]}
+        rowData={[]}
+        questionIcon="icon.png"
+        handleClick={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /create new cohort/i })).toBeTruthy();
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/HistogramPanel/chart/HistogramChartEmptyState.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/HistogramPanel/chart/HistogramChartEmptyState.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { HistogramChartEmptyState } from '../../../../HistogramPanel/chart/HistogramChartEmptyState';
+
+describe('HistogramChartEmptyState', () => {
+  it('renders accessible empty-state copy', () => {
+    render(<HistogramChartEmptyState />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('No data available.')).toBeInTheDocument();
+    expect(screen.getByText(/adjusting your filters/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/HistogramPanel/histogramConstants.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/HistogramPanel/histogramConstants.test.js
@@ -1,0 +1,21 @@
+import {
+  HISTOGRAM_CHART_PLOT_HEIGHT,
+  HISTOGRAM_CARD_MIN_WIDTH,
+  MAX_BARS_DISPLAYED,
+  CA_EXPANDED_CHART_MODAL_TAB_VENN,
+} from '../../../HistogramPanel/histogramConstants';
+
+describe('histogramConstants', () => {
+  it('defines histogram layout bounds', () => {
+    expect(HISTOGRAM_CARD_MIN_WIDTH).toBeLessThan(2000);
+    expect(HISTOGRAM_CHART_PLOT_HEIGHT).toBeGreaterThan(0);
+  });
+
+  it('limits bar counts for collapsed vs expanded views', () => {
+    expect(MAX_BARS_DISPLAYED).toBeLessThan(21);
+  });
+
+  it('defines expanded modal venn tab id', () => {
+    expect(CA_EXPANDED_CHART_MODAL_TAB_VENN).toBe('venn');
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/HistogramPanel/histogramLayoutUtils.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/HistogramPanel/histogramLayoutUtils.test.js
@@ -1,0 +1,34 @@
+import {
+  measureDragCardElement,
+  requiresCompactSpacing,
+} from '../../../HistogramPanel/utils/histogramLayoutUtils';
+
+describe('histogramLayoutUtils', () => {
+  describe('measureDragCardElement', () => {
+    it('returns null for missing element', () => {
+      expect(measureDragCardElement(null)).toBeNull();
+    });
+
+    it('returns null when rect is too small', () => {
+      const el = { getBoundingClientRect: () => ({ width: 4, height: 4 }) };
+      expect(measureDragCardElement(el)).toBeNull();
+    });
+
+    it('returns rounded dimensions', () => {
+      const el = { getBoundingClientRect: () => ({ width: 100.6, height: 200.4 }) };
+      expect(measureDragCardElement(el)).toEqual({ width: 101, height: 200 });
+    });
+  });
+
+  describe('requiresCompactSpacing', () => {
+    it('returns true for race, treatmentType, response', () => {
+      expect(requiresCompactSpacing('race')).toBe(true);
+      expect(requiresCompactSpacing('treatmentType')).toBe(true);
+      expect(requiresCompactSpacing('response')).toBe(true);
+    });
+
+    it('returns false for other datasets', () => {
+      expect(requiresCompactSpacing('sexAtBirth')).toBe(false);
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/HistogramPanel/histogramPopupKmDerived.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/HistogramPanel/histogramPopupKmDerived.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  useHistogramPopupFilteredKmData,
+  useHistogramPopupKmCohortColors,
+} from '../../../HistogramPanel/utils/histogramPopupKmDerived';
+
+function FilteredKmHarness({ kmPlotData, c1, c2, c3 }) {
+  const data = useHistogramPopupFilteredKmData(kmPlotData, c1, c2, c3);
+  return <div data-testid="count">{data.length}</div>;
+}
+
+function ColorsHarness({ c1, c2, c3 }) {
+  const colors = useHistogramPopupKmCohortColors(c1, c2, c3);
+  return <div data-testid="colors">{colors.length}</div>;
+}
+
+describe('histogramPopupKmDerived', () => {
+  const kmPlotData = [
+    { group: 'c1', value: 1 },
+    { group: 'cohort 2', value: 2 },
+    { group: 'other', value: 3 },
+  ];
+
+  it('filters KM data to selected cohort arms', () => {
+    render(<FilteredKmHarness kmPlotData={kmPlotData} c1={['a']} c2={[]} c3={[]} />);
+    expect(screen.getByTestId('count').textContent).toBe('1');
+  });
+
+  it('returns empty array when kmPlotData is missing', () => {
+    render(<FilteredKmHarness kmPlotData={null} c1={['a']} c2={[]} c3={[]} />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+  });
+
+  it('builds cohort colors for non-empty selections', () => {
+    render(<ColorsHarness c1={['a']} c2={['b']} c3={[]} />);
+    expect(screen.getByTestId('colors').textContent).toBe('2');
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/cohortAnalyzerPageLogic.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/cohortAnalyzerPageLogic.test.js
@@ -1,0 +1,155 @@
+import {
+  computeHasParticipantData,
+  getCohortAnalyzerTableMessage,
+  extractCohortNameFromVennSection,
+  filterVennSectionsForSelectedCohorts,
+  shouldClearRowDataOnEmptySelection,
+  countNonExampleCohorts,
+  canAddExampleCohorts,
+  buildExploreUploadPayload,
+  shouldSkipNavigateAwayModal,
+} from '../../cohortAnalyzerPageLogic';
+
+describe('cohortAnalyzerPageLogic', () => {
+  describe('computeHasParticipantData', () => {
+    it('returns false when state is null', () => {
+      expect(computeHasParticipantData(null, ['a'])).toBe(false);
+    });
+
+    it('returns false when selectedCohorts is not an array', () => {
+      expect(computeHasParticipantData({}, null)).toBe(false);
+    });
+
+    it('returns true when a selected cohort has participants', () => {
+      const state = { a: { participants: [{ id: 1 }] } };
+      expect(computeHasParticipantData(state, ['a'])).toBe(true);
+    });
+
+    it('returns false when selected cohort has empty participants', () => {
+      const state = { a: { participants: [] } };
+      expect(computeHasParticipantData(state, ['a'])).toBe(false);
+    });
+  });
+
+  describe('getCohortAnalyzerTableMessage', () => {
+    const tableConfig = { tableMsg: { noMatch: 'default' } };
+
+    it('returns explore message when cohort list is empty', () => {
+      expect(getCohortAnalyzerTableMessage([], [], tableConfig).noMatch)
+        .toContain('Explore Page');
+    });
+
+    it('returns tableConfig message when no section selected', () => {
+      expect(getCohortAnalyzerTableMessage(['c1'], [], tableConfig)).toEqual(tableConfig.tableMsg);
+    });
+
+    it('returns segment message when sections exist', () => {
+      const msg = getCohortAnalyzerTableMessage(['c1'], ['sec'], tableConfig);
+      expect(msg.noMatch).toContain('No data available');
+    });
+  });
+
+  describe('extractCohortNameFromVennSection', () => {
+    it('parses cohort name before count suffix', () => {
+      expect(extractCohortNameFromVennSection('Cohort A (12)')).toBe('Cohort A');
+    });
+
+    it('returns null when pattern does not match', () => {
+      expect(extractCohortNameFromVennSection('invalid')).toBeNull();
+    });
+  });
+
+  describe('filterVennSectionsForSelectedCohorts', () => {
+    it('returns empty when nodeIndex is not 0, 1, or 2', () => {
+      expect(filterVennSectionsForSelectedCohorts(['x'], ['Cohort A'], 3)).toEqual([]);
+    });
+
+    it('keeps single sections for selected cohorts', () => {
+      const result = filterVennSectionsForSelectedCohorts(
+        ['Cohort A (5)'],
+        ['Cohort A'],
+        0,
+      );
+      expect(result).toEqual(['Cohort A (5)']);
+    });
+
+    it('filters intersection sections to selected cohorts only', () => {
+      const result = filterVennSectionsForSelectedCohorts(
+        ['Cohort A (1) ∩ Cohort B (2)'],
+        ['Cohort A'],
+        1,
+      );
+      expect(result).toEqual(['Cohort A (1)']);
+    });
+
+    it('drops intersection when no cohort in selection matches', () => {
+      const result = filterVennSectionsForSelectedCohorts(
+        ['Cohort A (1) ∩ Cohort B (2)'],
+        ['Cohort C'],
+        0,
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('shouldClearRowDataOnEmptySelection', () => {
+    it('returns false when cohorts are selected', () => {
+      expect(shouldClearRowDataOnEmptySelection(['a'], {})).toBe(false);
+    });
+
+    it('returns true when empty and no navigation cohort', () => {
+      expect(shouldClearRowDataOnEmptySelection([], {})).toBe(true);
+    });
+
+    it('returns false when navigation state includes cohort', () => {
+      const location = { state: { cohort: { cohortId: 'x' } } };
+      expect(shouldClearRowDataOnEmptySelection([], location)).toBe(false);
+    });
+  });
+
+  describe('countNonExampleCohorts / canAddExampleCohorts', () => {
+    it('counts only non-example keys', () => {
+      const state = { a: {}, 'example cohort 1': {} };
+      expect(countNonExampleCohorts(state, ['example cohort 1'])).toEqual(['a']);
+    });
+
+    it('allows add when at limit', () => {
+      const state = { a: {}, b: {} };
+      expect(canAddExampleCohorts(state, [], 17)).toBe(true);
+    });
+
+    it('blocks add when over limit', () => {
+      const keys = Array.from({ length: 18 }, (_, i) => `c${i}`);
+      const state = keys.reduce((acc, k) => ({ ...acc, [k]: {} }), {});
+      expect(canAddExampleCohorts(state, [], 17)).toBe(false);
+    });
+  });
+
+  describe('buildExploreUploadPayload', () => {
+    it('maps row data to upload shape', () => {
+      const rowData = [
+        { participant_id: 'P1', dbgap_accession: 'phs1' },
+        { participant_id: 'P2', dbgap_accession: 'phs2' },
+      ];
+      const { upload, uploadMetadata } = buildExploreUploadPayload(rowData);
+      expect(upload).toHaveLength(2);
+      expect(uploadMetadata.fileContent).toBe('P1,P2');
+      expect(uploadMetadata.matched).toEqual(upload);
+    });
+  });
+
+  describe('shouldSkipNavigateAwayModal', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('returns true when hideNavigateModal is set', () => {
+      localStorage.setItem('hideNavigateModal', 'true');
+      expect(shouldSkipNavigateAwayModal()).toBe(true);
+    });
+
+    it('returns false otherwise', () => {
+      expect(shouldSkipNavigateAwayModal()).toBe(false);
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/cohortAnalyzerPageLogic.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/cohortAnalyzerPageLogic.test.js
@@ -110,7 +110,7 @@ describe('cohortAnalyzerPageLogic', () => {
   describe('countNonExampleCohorts / canAddExampleCohorts', () => {
     it('counts only non-example keys', () => {
       const state = { a: {}, 'example cohort 1': {} };
-      expect(countNonExampleCohorts(state, ['example cohort 1'])).toEqual(['a']);
+      expect(countNonExampleCohorts(state, ['example cohort 1'])).toBe(1);
     });
 
     it('allows add when at limit', () => {

--- a/src/pages/CohortAnalyzer/__tests__/unit/components/CohortAnalyzerSummaryView.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/components/CohortAnalyzerSummaryView.test.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CohortAnalyzerSummaryView } from '../../../components/CohortAnalyzerSummaryView';
+
+const classes = {
+  summaryViewShell: 'shell',
+  summaryTabsBar: 'bar',
+  summaryTabs: 'tabs',
+  summaryTab: 'tab',
+  summaryTabActive: 'active',
+  summaryTabsBarEnd: 'end',
+  summaryTabPanel: 'panel',
+};
+
+describe('CohortAnalyzerSummaryView', () => {
+  it('shows chart panel by default', () => {
+    render(
+      <CohortAnalyzerSummaryView
+        classes={classes}
+        activeView="chart"
+        setActiveView={jest.fn()}
+        chartPanel={<div data-testid="chart-panel">Chart</div>}
+        tablePanel={<div data-testid="table-panel">Table</div>}
+      />,
+    );
+    expect(screen.getByTestId('chart-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('table-panel')).not.toBeInTheDocument();
+  });
+
+  it('switches to table view on tab click', () => {
+    const setActiveView = jest.fn();
+    render(
+      <CohortAnalyzerSummaryView
+        classes={classes}
+        activeView="chart"
+        setActiveView={setActiveView}
+        chartPanel={<div>Chart</div>}
+        tablePanel={<div>Table</div>}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /table view/i }));
+    expect(setActiveView).toHaveBeenCalledWith('table');
+  });
+
+  it('renders trailing actions when provided', () => {
+    render(
+      <CohortAnalyzerSummaryView
+        classes={classes}
+        activeView="chart"
+        setActiveView={jest.fn()}
+        summaryTrailingActions={<button type="button">README</button>}
+        chartPanel={<div>Chart</div>}
+        tablePanel={<div>Table</div>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /readme/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/components/NoDataCard.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/components/NoDataCard.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { NoDataCard } from '../../../components/NoDataCard';
+
+describe('NoDataCard', () => {
+  it('renders empty-state message', () => {
+    render(<NoDataCard />);
+    expect(screen.getByText('No Data Available')).toBeInTheDocument();
+  });
+
+  it('renders placeholder chart svg', () => {
+    const { container } = render(<NoDataCard />);
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/config/CohortAnalyzerConfig.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/config/CohortAnalyzerConfig.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { exploreCCDIHubTooltip, exploreDashboardTooltip } from '../../../config/CohortAnalyzerConfig';
+
+describe('CohortAnalyzerConfig', () => {
+  it('renders explore CCDI Hub tooltip', () => {
+    const { container } = render(exploreCCDIHubTooltip);
+    expect(container.querySelector('p')).toBeTruthy();
+  });
+
+  it('renders explore dashboard tooltip text', () => {
+    const { container } = render(exploreDashboardTooltip);
+    expect(container.textContent).toContain('Explore Dashboard');
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/config/cohortAnalyzerChartCatalog.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/config/cohortAnalyzerChartCatalog.test.js
@@ -1,0 +1,34 @@
+import {
+  isAddChartDataTypeOnStrip,
+  hasAnyAddableChartCatalogEntry,
+  ADD_CHART_DATA_TYPES,
+} from '../../../config/cohortAnalyzerChartCatalog';
+
+describe('cohortAnalyzerChartCatalog', () => {
+  describe('isAddChartDataTypeOnStrip', () => {
+    it('returns false when entry has no datasetKey', () => {
+      expect(isAddChartDataTypeOnStrip({ id: 'x' }, [], [])).toBe(false);
+    });
+
+    it('detects survival already on strip', () => {
+      const entry = ADD_CHART_DATA_TYPES.find((e) => e.id === 'survivalAnalysis');
+      expect(isAddChartDataTypeOnStrip(entry, [], ['survivalAnalysis'])).toBe(true);
+    });
+
+    it('detects histogram dataset on strip', () => {
+      const entry = ADD_CHART_DATA_TYPES.find((e) => e.id === 'race');
+      expect(isAddChartDataTypeOnStrip(entry, ['race'], [])).toBe(true);
+    });
+  });
+
+  describe('hasAnyAddableChartCatalogEntry', () => {
+    it('returns true when an available chart is not on layout', () => {
+      expect(hasAnyAddableChartCatalogEntry([], [])).toBe(true);
+    });
+
+    it('returns false when all available charts are present', () => {
+      const strip = ['sexAtBirth', 'race', 'treatmentType', 'response', 'survivalAnalysis'];
+      expect(hasAnyAddableChartCatalogEntry(strip, ['survivalAnalysis'])).toBe(false);
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/config/cohortAnalyzerViewPercentDefaults.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/config/cohortAnalyzerViewPercentDefaults.test.js
@@ -1,0 +1,93 @@
+import {
+  defaultVennOuterHeightPx,
+  defaultVennOuterPx,
+  defaultHistogramPlotHeightPx,
+  defaultHistogramStripDropSlotWidthPx,
+  defaultHistogramCardOuterMinHeightPx,
+  defaultVennModalSlotPx,
+  defaultModalKmChartHeightPx,
+  defaultModalHistogramDatasetChartHeightPx,
+  vennChartSlotDimensionsFromOuterPx,
+  chartVennFallbackCanvasDimensionsPx,
+} from '../../../config/cohortAnalyzerViewPercentDefaults';
+
+describe('cohortAnalyzerViewPercentDefaults', () => {
+  const originalInnerWidth = window.innerWidth;
+  const originalInnerHeight = window.innerHeight;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: originalInnerHeight, writable: true });
+  });
+
+  describe('defaultVennOuterHeightPx', () => {
+    it('uses big screen height at wide viewport', () => {
+      Object.defineProperty(window, 'innerWidth', { value: 1900, writable: true });
+      expect(defaultVennOuterHeightPx()).toBe(580);
+    });
+
+    it('uses compact height at narrow viewport', () => {
+      Object.defineProperty(window, 'innerWidth', { value: 1200, writable: true });
+      expect(defaultVennOuterHeightPx()).toBe(400);
+    });
+  });
+
+  describe('defaultVennOuterPx', () => {
+    it('returns width and height within bounds', () => {
+      Object.defineProperty(window, 'innerWidth', { value: 1600, writable: true });
+      const { width, height } = defaultVennOuterPx();
+      expect(width).toBeGreaterThanOrEqual(400);
+      expect(height).toBeGreaterThanOrEqual(280);
+    });
+  });
+
+  describe('histogram defaults', () => {
+    it('returns plot height within min/max', () => {
+      Object.defineProperty(window, 'innerHeight', { value: 900, writable: true });
+      const h = defaultHistogramPlotHeightPx();
+      expect(h).toBeGreaterThanOrEqual(120);
+      expect(h).toBeLessThanOrEqual(800);
+    });
+
+    it('returns drop slot width from viewport', () => {
+      Object.defineProperty(window, 'innerWidth', { value: 1400, writable: true });
+      expect(defaultHistogramStripDropSlotWidthPx()).toBeGreaterThan(0);
+    });
+
+    it('computes card outer min height from plot height', () => {
+      expect(defaultHistogramCardOuterMinHeightPx(200)).toBeGreaterThan(200);
+    });
+  });
+
+  describe('modal defaults', () => {
+    it('returns venn modal slot dimensions', () => {
+      const slot = defaultVennModalSlotPx();
+      expect(slot.slotWidth).toBeGreaterThan(0);
+      expect(slot.slotHeight).toBeGreaterThan(0);
+    });
+
+    it('returns km and histogram modal heights', () => {
+      Object.defineProperty(window, 'innerHeight', { value: 900, writable: true });
+      expect(defaultModalKmChartHeightPx()).toBeGreaterThanOrEqual(260);
+      expect(defaultModalHistogramDatasetChartHeightPx()).toBeGreaterThanOrEqual(460);
+    });
+  });
+
+  describe('vennChartSlotDimensionsFromOuterPx', () => {
+    it('derives slot from outer dimensions', () => {
+      const slot = vennChartSlotDimensionsFromOuterPx(500, 400);
+      expect(slot.slotWidth).toBeGreaterThanOrEqual(200);
+      expect(slot.slotHeight).toBeGreaterThanOrEqual(140);
+    });
+  });
+
+  describe('chartVennFallbackCanvasDimensionsPx', () => {
+    it('returns smaller canvas for two cohorts', () => {
+      Object.defineProperty(window, 'innerWidth', { value: 1600, writable: true });
+      Object.defineProperty(window, 'innerHeight', { value: 900, writable: true });
+      const two = chartVennFallbackCanvasDimensionsPx(2);
+      const three = chartVennFallbackCanvasDimensionsPx(3);
+      expect(two.width).toBeLessThan(three.width);
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/controllers/CohortAnalyzerController.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/controllers/CohortAnalyzerController.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('../../../../../components/CohortSelectorState/CohortStateContext', () => {
+  const ReactMock = require('react');
+  return {
+    CohortStateProvider: ({ children }) => <div data-testid="cohort-state">{children}</div>,
+    CohortStateContext: ReactMock.createContext({ state: {}, dispatch: jest.fn() }),
+  };
+});
+
+jest.mock('../../../../../components/CohortModal/CohortModalContext', () => {
+  const ReactMock = require('react');
+  return {
+    CohortModalProvider: ({ children }) => <div data-testid="cohort-modal">{children}</div>,
+    CohortModalContext: ReactMock.createContext({}),
+  };
+});
+
+jest.mock('../../../context/CohortAnalyzerContext', () => ({
+  CohortAnalyzerProvider: ({ children }) => <div data-testid="analyzer-context">{children}</div>,
+}));
+
+jest.mock('../../../CohortAnalyzer', () => ({
+  CohortAnalyzer: () => <div data-testid="cohort-analyzer-page">Analyzer</div>,
+}));
+
+import CohortAnalyzerController from '../../../controllers/CohortAnalyzerController';
+
+describe('CohortAnalyzerController', () => {
+  it('wraps CohortAnalyzer with required providers', () => {
+    render(<CohortAnalyzerController />);
+    expect(screen.getByTestId('cohort-state')).toBeInTheDocument();
+    expect(screen.getByTestId('cohort-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('analyzer-context')).toBeInTheDocument();
+    expect(screen.getByTestId('cohort-analyzer-page')).toBeInTheDocument();
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/customCheckbox/CustomCheckbox.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/customCheckbox/CustomCheckbox.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CustomCheckbox from '../../../customCheckbox/CustomCheckbox';
+
+describe('CustomCheckbox', () => {
+  it('calls handleCheckbox when clicked and not disabled', () => {
+    const handleCheckbox = jest.fn();
+    render(
+      <CustomCheckbox
+        selectedCohorts={['a']}
+        cohort="b"
+        handleCheckbox={handleCheckbox}
+      />,
+    );
+    fireEvent.click(screen.getByAltText('checkbox b'));
+    expect(handleCheckbox).toHaveBeenCalledWith('b', expect.any(Object));
+  });
+
+  it('does not call handleCheckbox when three cohorts already selected', () => {
+    const handleCheckbox = jest.fn();
+    render(
+      <CustomCheckbox
+        selectedCohorts={['a', 'b', 'c']}
+        cohort="d"
+        handleCheckbox={handleCheckbox}
+      />,
+    );
+    fireEvent.click(screen.getByAltText('checkbox d'));
+    expect(handleCheckbox).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/downloads/cohortAnalyzerDownloadAll.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/downloads/cohortAnalyzerDownloadAll.test.js
@@ -63,6 +63,10 @@ describe('cohortAnalyzerDownloadAll', () => {
   });
 
   describe('downloadTextFile', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it('creates a download link and triggers click', () => {
       const click = jest.fn();
       const anchor = { click, href: '', download: '' };

--- a/src/pages/CohortAnalyzer/__tests__/unit/downloads/cohortAnalyzerDownloadAll.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/downloads/cohortAnalyzerDownloadAll.test.js
@@ -1,0 +1,84 @@
+jest.mock('html-to-image', () => ({}));
+jest.mock('jspdf', () => ({
+  jsPDF: jest.fn().mockImplementation(() => ({
+    addImage: jest.fn(),
+    save: jest.fn(),
+  })),
+}));
+
+import {
+  CHART_EXPORT_PADDING_PX,
+  buildRawCohortChartTabularRows,
+  formatRowsAsTsv,
+  formatRowsAsCsv,
+  downloadTextFile,
+} from '../../../downloads/cohortAnalyzerDownloadAll';
+
+describe('cohortAnalyzerDownloadAll', () => {
+  it('exports chart padding constant', () => {
+    expect(CHART_EXPORT_PADDING_PX).toBe(50);
+  });
+
+  describe('buildRawCohortChartTabularRows', () => {
+    it('flattens histogram fetched data into rows', () => {
+      const rows = buildRawCohortChartTabularRows({
+        histogram: {
+          fetchedData: {
+            sex_at_birth: [{ name: 'Male', cohort: 'A', count: 3 }],
+          },
+          viewType: { sexAtBirth: 'count' },
+        },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].chart_property).toBe('sex_at_birth');
+      expect(rows[0].group).toBe('Male');
+      expect(rows[0].aggregation).toBe('count');
+    });
+
+    it('returns empty array when payload has no histogram', () => {
+      expect(buildRawCohortChartTabularRows({})).toEqual([]);
+    });
+  });
+
+  describe('formatRowsAsTsv / formatRowsAsCsv', () => {
+    const rows = [
+      { a: 'x', b: 'y' },
+      { a: 'comma,here', b: 'tab\there' },
+    ];
+
+    it('formats TSV with headers', () => {
+      const tsv = formatRowsAsTsv(rows);
+      expect(tsv.split('\n')[0]).toBe('a\tb');
+    });
+
+    it('escapes CSV special characters', () => {
+      const csv = formatRowsAsCsv(rows);
+      expect(csv).toContain('"comma,here"');
+    });
+
+    it('returns empty string for no rows', () => {
+      expect(formatRowsAsTsv([])).toBe('');
+      expect(formatRowsAsCsv([])).toBe('');
+    });
+  });
+
+  describe('downloadTextFile', () => {
+    it('creates a download link and triggers click', () => {
+      const click = jest.fn();
+      const anchor = { click, href: '', download: '' };
+      const createObjectURL = jest.fn(() => 'blob:mock');
+      const revokeObjectURL = jest.fn();
+      global.URL.createObjectURL = createObjectURL;
+      global.URL.revokeObjectURL = revokeObjectURL;
+      jest.spyOn(document, 'createElement').mockReturnValue(anchor);
+      jest.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+      jest.spyOn(document.body, 'removeChild').mockImplementation(() => {});
+
+      downloadTextFile('hello', 'out.txt', 'text/plain');
+
+      expect(createObjectURL).toHaveBeenCalled();
+      expect(click).toHaveBeenCalled();
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/store/besideStripPromotion.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/store/besideStripPromotion.test.js
@@ -1,0 +1,29 @@
+import { buildStripOrderPromotingBeside } from '../../../store/besideStripPromotion';
+
+describe('besideStripPromotion', () => {
+  describe('buildStripOrderPromotingBeside', () => {
+    it('returns null for survivalAnalysis', () => {
+      expect(buildStripOrderPromotingBeside(['race'], ['race'], 'survivalAnalysis')).toBeNull();
+    });
+
+    it('returns null without promoted dataset', () => {
+      expect(buildStripOrderPromotingBeside(['race'], ['race'], null)).toBeNull();
+    });
+
+    it('promotes dataset to front of strip order', () => {
+      const next = buildStripOrderPromotingBeside(
+        ['sexAtBirth', 'race'],
+        ['sexAtBirth', 'race'],
+        'race',
+      );
+      expect(next[0]).toBe('race');
+      expect(next).toContain('sexAtBirth');
+    });
+
+    it('appends missing visible datasets', () => {
+      const next = buildStripOrderPromotingBeside(['race'], ['race', 'sexAtBirth'], 'sexAtBirth');
+      expect(next).toContain('sexAtBirth');
+      expect(next[0]).toBe('sexAtBirth');
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerDefaultPanelRegistry.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerDefaultPanelRegistry.test.js
@@ -1,0 +1,17 @@
+import { buildDefaultCohortAnalyzerPanelRegistry, COHORT_ANALYZER_HISTOGRAM_TITLES } from '../../../store/cohortAnalyzerDefaultPanelRegistry';
+
+describe('cohortAnalyzerDefaultPanelRegistry', () => {
+  describe('buildDefaultCohortAnalyzerPanelRegistry', () => {
+    it('includes venn and survival panels', () => {
+      const registry = buildDefaultCohortAnalyzerPanelRegistry();
+      expect(registry.venn.kind).toBe('venn');
+      expect(registry.survival.chartKey).toBe('survivalAnalysis');
+    });
+
+    it('includes histogram dataset panels except survival duplicate', () => {
+      const registry = buildDefaultCohortAnalyzerPanelRegistry();
+      expect(registry.sexAtBirth.label).toBe(COHORT_ANALYZER_HISTOGRAM_TITLES.sexAtBirth);
+      expect(registry.race.kind).toBe('histogram');
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerLayoutActionTypes.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerLayoutActionTypes.test.js
@@ -1,0 +1,15 @@
+import * as actionTypes from '../../../store/cohortAnalyzerLayoutActionTypes';
+
+describe('cohortAnalyzerLayoutActionTypes', () => {
+  it('exports unique string action types', () => {
+    const values = Object.values(actionTypes);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+
+  it('uses cohortAnalyzerLayout namespace prefix', () => {
+    Object.values(actionTypes).forEach((type) => {
+      expect(type).toMatch(/^cohortAnalyzerLayout\//);
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerLayoutActions.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerLayoutActions.test.js
@@ -1,0 +1,88 @@
+import {
+  setTopRowOrder,
+  setStripOrder,
+  setBesideStripPanelId,
+  promoteBesideStripLayout,
+  moveTopRowPanelIntoStrip,
+  upsertPanelRegistry,
+  patchPanelVisibility,
+  patchUiFlags,
+  patchChartVisuals,
+  setPanelSizeForId,
+  setPanelSize,
+  setWorkspaceGridLayout,
+  hydrateCohortAnalyzerLayout,
+  resetCohortAnalyzerLayout,
+  setSurvivalBesideFromSelection,
+} from '../../../store/cohortAnalyzerLayoutActions';
+import {
+  CA_LAYOUT_SET_TOP_ROW_ORDER,
+  CA_LAYOUT_SET_STRIP_ORDER,
+  CA_LAYOUT_RESET,
+} from '../../../store/cohortAnalyzerLayoutActionTypes';
+
+describe('cohortAnalyzerLayoutActions', () => {
+  it('setTopRowOrder returns action', () => {
+    expect(setTopRowOrder(['venn'])).toEqual({
+      type: CA_LAYOUT_SET_TOP_ROW_ORDER,
+      payload: ['venn'],
+    });
+  });
+
+  it('setStripOrder attaches meta when userInitiated', () => {
+    expect(setStripOrder(['race'], { userInitiated: true })).toEqual({
+      type: CA_LAYOUT_SET_STRIP_ORDER,
+      payload: ['race'],
+      meta: { userInitiated: true },
+    });
+  });
+
+  it('setStripOrder omits meta when not user initiated', () => {
+    expect(setStripOrder(['race'])).toEqual({
+      type: CA_LAYOUT_SET_STRIP_ORDER,
+      payload: ['race'],
+    });
+  });
+
+  it('setBesideStripPanelId returns action', () => {
+    expect(setBesideStripPanelId('race').type).toBeDefined();
+  });
+
+  it('promoteBesideStripLayout returns action', () => {
+    const payload = { stripOrder: ['race'], besideStripPanelId: 'race' };
+    expect(promoteBesideStripLayout(payload).payload).toEqual(payload);
+  });
+
+  it('moveTopRowPanelIntoStrip returns action', () => {
+    expect(moveTopRowPanelIntoStrip({ panel: 'venn', insertBeforeDataset: 'race' }).payload.panel)
+      .toBe('venn');
+  });
+
+  it('upsertPanelRegistry returns action', () => {
+    expect(upsertPanelRegistry({ race: { kind: 'histogram' } }).payload.race).toBeDefined();
+  });
+
+  it('patchPanelVisibility returns action', () => {
+    expect(patchPanelVisibility({ race: true }).payload).toEqual({ race: true });
+  });
+
+  it('patchUiFlags and setSurvivalBesideFromSelection', () => {
+    expect(patchUiFlags({ flag: 1 }).type).toBeDefined();
+    expect(setSurvivalBesideFromSelection(true).payload.survivalBesideFromSelection).toBe(true);
+  });
+
+  it('patchChartVisuals returns action', () => {
+    expect(patchChartVisuals({ race: 'pie' }).payload).toEqual({ race: 'pie' });
+  });
+
+  it('setPanelSizeForId and setPanelSize return actions', () => {
+    expect(setPanelSizeForId('venn', { width: 1 }).payload.panelId).toBe('venn');
+    expect(setPanelSize({ panel: 'histogram', dataset: 'race', size: {} }).payload.dataset).toBe('race');
+  });
+
+  it('setWorkspaceGridLayout hydrate and reset', () => {
+    expect(setWorkspaceGridLayout([]).payload).toEqual([]);
+    expect(hydrateCohortAnalyzerLayout({}).type).toBeDefined();
+    expect(resetCohortAnalyzerLayout()).toEqual({ type: CA_LAYOUT_RESET });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerLayoutConstants.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerLayoutConstants.test.js
@@ -1,0 +1,24 @@
+import {
+  CA_LAYOUT_SLOT,
+  CA_PANEL_KIND,
+  CA_TOP_ROW_GAP_PX,
+  CA_VENN_OUTER_MIN_W,
+  CA_SURVIVAL_CARD_MIN_WIDTH,
+} from '../../../store/cohortAnalyzerLayoutConstants';
+
+describe('cohortAnalyzerLayoutConstants', () => {
+  it('defines layout slot ids', () => {
+    expect(CA_LAYOUT_SLOT.VENN).toBe('venn');
+    expect(CA_LAYOUT_SLOT.SURVIVAL).toBe('survival');
+  });
+
+  it('defines panel kind strings', () => {
+    expect(CA_PANEL_KIND.HISTOGRAM).toBe('histogram');
+    expect(CA_PANEL_KIND.VENN).toBe('venn');
+  });
+
+  it('exposes sizing constants', () => {
+    expect(CA_TOP_ROW_GAP_PX).toBeGreaterThan(0);
+    expect(CA_VENN_OUTER_MIN_W).toBeLessThan(CA_SURVIVAL_CARD_MIN_WIDTH);
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerLayoutReducer.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/store/cohortAnalyzerLayoutReducer.test.js
@@ -1,0 +1,240 @@
+import cohortAnalyzerLayoutReducer, {
+  cohortAnalyzerLayoutInitialState,
+  clampSurvivalPanelSize,
+  isCohortAnalyzerLayoutPristine,
+  migrateLayoutPayloadToV2,
+} from '../../../store/cohortAnalyzerLayoutReducer';
+import {
+  CA_LAYOUT_SET_TOP_ROW_ORDER,
+  CA_LAYOUT_SET_STRIP_ORDER,
+  CA_LAYOUT_SET_BESIDE_STRIP_PANEL,
+  CA_LAYOUT_PROMOTE_BESIDE_STRIP,
+  CA_LAYOUT_MOVE_TOP_ROW_INTO_STRIP,
+  CA_LAYOUT_PATCH_VISIBILITY,
+  CA_LAYOUT_SET_PANEL_SIZE,
+  CA_LAYOUT_SET_PANEL_SIZE_FOR_ID,
+  CA_LAYOUT_UPSERT_PANEL_REGISTRY,
+  CA_LAYOUT_PATCH_UI_FLAGS,
+  CA_LAYOUT_PATCH_CHART_VISUALS,
+  CA_LAYOUT_SET_WORKSPACE_GRID,
+  CA_LAYOUT_HYDRATE,
+  CA_LAYOUT_RESET,
+} from '../../../store/cohortAnalyzerLayoutActionTypes';
+
+describe('cohortAnalyzerLayoutReducer', () => {
+  describe('clampSurvivalPanelSize', () => {
+    it('clamps width and height to survival bounds', () => {
+      const result = clampSurvivalPanelSize({ width: 10, height: 10 });
+      expect(result.width).toBeGreaterThanOrEqual(420);
+      expect(result.height).toBeGreaterThanOrEqual(444);
+    });
+
+    it('returns size unchanged when not an object', () => {
+      expect(clampSurvivalPanelSize(null)).toBeNull();
+    });
+  });
+
+  describe('isCohortAnalyzerLayoutPristine', () => {
+    it('returns true when layout state is missing', () => {
+      expect(isCohortAnalyzerLayoutPristine(null)).toBe(true);
+    });
+
+    it('returns false after user layout change', () => {
+      expect(isCohortAnalyzerLayoutPristine({ userLayoutChanged: true })).toBe(false);
+    });
+  });
+
+  describe('migrateLayoutPayloadToV2', () => {
+    it('returns initial state for invalid payload', () => {
+      const migrated = migrateLayoutPayloadToV2(null);
+      expect(migrated.schemaVersion).toBe(2);
+      expect(migrated.topRowOrder).toEqual(['venn', 'survival']);
+    });
+
+    it('migrates v1 panelSizes into sizes', () => {
+      const migrated = migrateLayoutPayloadToV2({
+        schemaVersion: 1,
+        panelSizes: {
+          venn: { width: 400 },
+          survival: { width: 500, height: 600 },
+          histogram: { race: { width: 300 } },
+        },
+      });
+      expect(migrated.sizes.venn.width).toBe(400);
+      expect(migrated.sizes.survival.width).toBe(500);
+      expect(migrated.sizes.race.width).toBe(300);
+    });
+
+    it('migrates legacy field names on v1 payload', () => {
+      const migrated = migrateLayoutPayloadToV2({
+        schemaVersion: 1,
+        topRowPanelOrder: ['survival', 'venn'],
+        histogramQueueOrder: ['race'],
+        besideVennHistogramId: 'sexAtBirth',
+        panelVisibility: { race: true },
+        survivalBesideFromSelection: false,
+      });
+      expect(migrated.topRowOrder).toEqual(['survival', 'venn']);
+      expect(migrated.stripOrder).toEqual(['race']);
+      expect(migrated.besideStripPanelId).toBe('sexAtBirth');
+      expect(migrated.visibility.race).toBe(true);
+      expect(migrated.uiFlags.survivalBesideFromSelection).toBe(false);
+    });
+  });
+
+  describe('reducer actions', () => {
+    it('CA_LAYOUT_SET_TOP_ROW_ORDER sets order and userLayoutChanged', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_SET_TOP_ROW_ORDER,
+        payload: ['survival', 'venn'],
+      });
+      expect(next.topRowOrder).toEqual(['survival', 'venn']);
+      expect(next.userLayoutChanged).toBe(true);
+    });
+
+    it('CA_LAYOUT_SET_STRIP_ORDER respects userInitiated meta', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_SET_STRIP_ORDER,
+        payload: ['race'],
+        meta: { userInitiated: true },
+      });
+      expect(next.stripOrder).toEqual(['race']);
+      expect(next.userLayoutChanged).toBe(true);
+    });
+
+    it('CA_LAYOUT_SET_BESIDE_STRIP_PANEL updates beside id', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_SET_BESIDE_STRIP_PANEL,
+        payload: 'race',
+      });
+      expect(next.besideStripPanelId).toBe('race');
+    });
+
+    it('CA_LAYOUT_PROMOTE_BESIDE_STRIP updates strip and beside', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_PROMOTE_BESIDE_STRIP,
+        payload: { stripOrder: ['race'], besideStripPanelId: 'race' },
+      });
+      expect(next.stripOrder).toEqual(['race']);
+      expect(next.besideStripPanelId).toBe('race');
+    });
+
+    it('CA_LAYOUT_PROMOTE_BESIDE_STRIP ignores invalid payload', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_PROMOTE_BESIDE_STRIP,
+        payload: { stripOrder: [], besideStripPanelId: '' },
+      });
+      expect(next).toBe(cohortAnalyzerLayoutInitialState);
+    });
+
+    it('CA_LAYOUT_MOVE_TOP_ROW_INTO_STRIP moves panel into strip', () => {
+      const state = { ...cohortAnalyzerLayoutInitialState, topRowOrder: ['venn', 'survival'] };
+      const next = cohortAnalyzerLayoutReducer(state, {
+        type: CA_LAYOUT_MOVE_TOP_ROW_INTO_STRIP,
+        payload: { panel: 'venn', insertBeforeDataset: 'race' },
+      });
+      expect(next.topRowOrder).not.toContain('venn');
+      expect(next.stripOrder).toContain('venn');
+    });
+
+    it('CA_LAYOUT_PATCH_VISIBILITY merges visibility', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_PATCH_VISIBILITY,
+        payload: { race: false },
+      });
+      expect(next.visibility.race).toBe(false);
+    });
+
+    it('CA_LAYOUT_SET_PANEL_SIZE_FOR_ID clamps survival size', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_SET_PANEL_SIZE_FOR_ID,
+        payload: { panelId: 'survival', size: { width: 100, height: 100 } },
+      });
+      expect(next.sizes.survival.width).toBeGreaterThanOrEqual(420);
+    });
+
+    it('CA_LAYOUT_SET_PANEL_SIZE uses legacy payload shape', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_SET_PANEL_SIZE,
+        payload: { panel: 'histogram', dataset: 'race', size: { width: 300 } },
+      });
+      expect(next.sizes.race.width).toBe(300);
+    });
+
+    it('CA_LAYOUT_SET_PANEL_SIZE ignores invalid legacy payload', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_SET_PANEL_SIZE,
+        payload: { panel: 'histogram', size: { width: 300 } },
+      });
+      expect(next).toBe(cohortAnalyzerLayoutInitialState);
+    });
+
+    it('CA_LAYOUT_SET_PANEL_SIZE_FOR_ID ignores missing panelId', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_SET_PANEL_SIZE_FOR_ID,
+        payload: { size: { width: 1 } },
+      });
+      expect(next).toBe(cohortAnalyzerLayoutInitialState);
+    });
+
+    it('CA_LAYOUT_PROMOTE_BESIDE_STRIP ignores invalid payload', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_PROMOTE_BESIDE_STRIP,
+        payload: { stripOrder: 'not-array', besideStripPanelId: 'race' },
+      });
+      expect(next).toBe(cohortAnalyzerLayoutInitialState);
+    });
+
+    it('CA_LAYOUT_PATCH_UI_FLAGS merges ui flags', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_PATCH_UI_FLAGS,
+        payload: { survivalBesideFromSelection: true },
+      });
+      expect(next.uiFlags.survivalBesideFromSelection).toBe(true);
+    });
+
+    it('CA_LAYOUT_UPSERT_PANEL_REGISTRY merges registry', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_UPSERT_PANEL_REGISTRY,
+        payload: { race: { kind: 'histogram', chartKey: 'race' } },
+      });
+      expect(next.panelRegistry.race.chartKey).toBe('race');
+    });
+
+    it('CA_LAYOUT_PATCH_CHART_VISUALS merges chart visuals', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_PATCH_CHART_VISUALS,
+        payload: { race: 'pie' },
+      });
+      expect(next.chartVisualByPanelId.race).toBe('pie');
+    });
+
+    it('CA_LAYOUT_SET_WORKSPACE_GRID stores grid layout', () => {
+      const grid = [{ i: 'a' }];
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_SET_WORKSPACE_GRID,
+        payload: grid,
+      });
+      expect(next.workspaceGridLayout).toEqual(grid);
+    });
+
+    it('CA_LAYOUT_HYDRATE normalizes payload', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, {
+        type: CA_LAYOUT_HYDRATE,
+        payload: { schemaVersion: 2, stripOrder: ['race'] },
+      });
+      expect(next.stripOrder).toEqual(['race']);
+    });
+
+    it('CA_LAYOUT_RESET returns initial state', () => {
+      const dirty = { ...cohortAnalyzerLayoutInitialState, userLayoutChanged: true };
+      const next = cohortAnalyzerLayoutReducer(dirty, { type: CA_LAYOUT_RESET });
+      expect(next).toEqual(cohortAnalyzerLayoutInitialState);
+    });
+
+    it('returns same state for unknown action', () => {
+      const next = cohortAnalyzerLayoutReducer(cohortAnalyzerLayoutInitialState, { type: 'UNKNOWN' });
+      expect(next).toBe(cohortAnalyzerLayoutInitialState);
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/store/panelDnD.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/store/panelDnD.test.js
@@ -1,0 +1,97 @@
+import {
+  CA_PANEL_DRAG_MIME,
+  encodePanelDragPayload,
+  decodePanelDragPayload,
+  parseDragDataTransfer,
+  parseDragDataTransferForDrop,
+} from '../../../store/panelDnD';
+
+describe('panelDnD', () => {
+  describe('encodePanelDragPayload / decodePanelDragPayload', () => {
+    it('round-trips venn payload', () => {
+      const raw = encodePanelDragPayload({ kind: 'venn' });
+      expect(decodePanelDragPayload(raw)).toEqual({ kind: 'venn', dataset: null });
+    });
+
+    it('round-trips histogram payload', () => {
+      const raw = encodePanelDragPayload({ kind: 'histogram', dataset: 'race' });
+      expect(decodePanelDragPayload(raw)).toEqual({ kind: 'histogram', dataset: 'race' });
+    });
+
+    it('returns null for invalid json', () => {
+      expect(decodePanelDragPayload('not-json')).toBeNull();
+    });
+
+    it('returns null for empty input', () => {
+      expect(decodePanelDragPayload('')).toBeNull();
+      expect(decodePanelDragPayload(null)).toBeNull();
+    });
+
+    it('returns null for unknown kind', () => {
+      expect(decodePanelDragPayload(JSON.stringify({ kind: 'other' }))).toBeNull();
+    });
+
+    it('returns empty string when JSON.stringify fails', () => {
+      const circular = {};
+      circular.self = circular;
+      expect(encodePanelDragPayload(circular)).toBe('');
+    });
+  });
+
+  describe('parseDragDataTransfer', () => {
+    it('reads mime payload', () => {
+      const dt = {
+        getData: (type) => (type === CA_PANEL_DRAG_MIME
+          ? encodePanelDragPayload({ kind: 'survival' })
+          : ''),
+      };
+      expect(parseDragDataTransfer(dt)).toEqual({ kind: 'survival', dataset: null });
+    });
+
+    it('reads plain venn/survival text', () => {
+      const dt = { getData: () => 'venn' };
+      expect(parseDragDataTransfer(dt)).toEqual({ kind: 'venn', dataset: null });
+    });
+
+    it('reads plain histogram dataset id', () => {
+      const dt = { getData: () => 'sexAtBirth' };
+      expect(parseDragDataTransfer(dt)).toEqual({ kind: 'histogram', dataset: 'sexAtBirth' });
+    });
+
+    it('returns null when no data', () => {
+      expect(parseDragDataTransfer(null)).toBeNull();
+      expect(parseDragDataTransfer({ getData: () => '' })).toBeNull();
+    });
+  });
+
+  describe('parseDragDataTransferForDrop', () => {
+    it('falls back to scanning types', () => {
+      const payload = encodePanelDragPayload({ kind: 'histogram', dataset: 'race' });
+      const dt = {
+        getData: (type) => (type === 'application/json' ? payload : ''),
+        types: ['application/json'],
+      };
+      expect(parseDragDataTransferForDrop(dt)).toEqual({ kind: 'histogram', dataset: 'race' });
+    });
+
+    it('skips types when getData throws', () => {
+      const payload = encodePanelDragPayload({ kind: 'venn' });
+      const dt = {
+        types: ['broken', CA_PANEL_DRAG_MIME],
+        getData: (type) => {
+          if (type === 'broken') throw new Error('blocked');
+          return type === CA_PANEL_DRAG_MIME ? payload : '';
+        },
+      };
+      expect(parseDragDataTransferForDrop(dt)).toEqual({ kind: 'venn', dataset: null });
+    });
+
+    it('returns survival from trimmed type value', () => {
+      const dt = {
+        getData: () => '  survival  ',
+        types: ['text/plain'],
+      };
+      expect(parseDragDataTransferForDrop(dt)).toEqual({ kind: 'survival', dataset: null });
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/store/topRowStripOrder.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/store/topRowStripOrder.test.js
@@ -1,0 +1,41 @@
+import {
+  isStripOrderHistogramOnlyId,
+  insertTopRowPanelIntoStripOrder,
+  filterTopRowOrderAfterMove,
+} from '../../../store/topRowStripOrder';
+
+describe('topRowStripOrder', () => {
+  describe('isStripOrderHistogramOnlyId', () => {
+    it('returns false for venn and survival tokens', () => {
+      expect(isStripOrderHistogramOnlyId('venn')).toBe(false);
+      expect(isStripOrderHistogramOnlyId('survivalAnalysis')).toBe(false);
+    });
+
+    it('returns true for histogram dataset ids', () => {
+      expect(isStripOrderHistogramOnlyId('race')).toBe(true);
+    });
+  });
+
+  describe('insertTopRowPanelIntoStripOrder', () => {
+    it('inserts venn before target dataset', () => {
+      const next = insertTopRowPanelIntoStripOrder(['race', 'sexAtBirth'], 'venn', 'sexAtBirth');
+      expect(next).toEqual(['race', 'venn', 'sexAtBirth']);
+    });
+
+    it('appends survival to end of strip', () => {
+      const next = insertTopRowPanelIntoStripOrder(['race'], 'survival', 'race');
+      expect(next).toEqual(['race', 'survivalAnalysis']);
+    });
+
+    it('removes duplicate token before insert', () => {
+      const next = insertTopRowPanelIntoStripOrder(['venn', 'race'], 'venn', 'race');
+      expect(next.filter((id) => id === 'venn')).toHaveLength(1);
+    });
+  });
+
+  describe('filterTopRowOrderAfterMove', () => {
+    it('removes panel from top row order', () => {
+      expect(filterTopRowOrderAfterMove(['venn', 'survival'], 'venn')).toEqual(['survival']);
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
@@ -6,9 +6,9 @@ describe('cohortAnalyzerThemeConfig', () => {
     expect(cohortAnalyzerThemeConfig.tblContainer).toBeDefined();
   });
 
-  it('left-aligns table header cells', () => {
+  it('center-aligns table header cells', () => {
     const cell = cohortAnalyzerThemeConfig.tblHeader.MuiTableCell.root;
-    expect(cell.textAlign).toBe('left');
+    expect(cell.textAlign).toBe('center');
     expect(cell.color).toBe('#0F253A');
   });
 

--- a/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
@@ -1,0 +1,20 @@
+import { cohortAnalyzerThemeConfig } from '../../../styling/cohortAnalyzerThemeConfig';
+
+describe('cohortAnalyzerThemeConfig', () => {
+  it('extends base theme config', () => {
+    expect(cohortAnalyzerThemeConfig.tblHeader).toBeDefined();
+    expect(cohortAnalyzerThemeConfig.tblContainer).toBeDefined();
+  });
+
+  it('left-aligns table header cells', () => {
+    const cell = cohortAnalyzerThemeConfig.tblHeader.MuiTableCell.root;
+    expect(cell.textAlign).toBe('left');
+    expect(cell.color).toBe('#0F253A');
+  });
+
+  it('styles first-column body cells with purple links', () => {
+    const firstCol = cohortAnalyzerThemeConfig.tblBody.MuiTableCell.body['&:first-of-type'];
+    expect(firstCol.color).toBe('#763E96');
+    expect(firstCol.fontWeight).toBe(600);
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/utils/cohortAnalyzerChartPreview.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/utils/cohortAnalyzerChartPreview.test.js
@@ -1,0 +1,72 @@
+import {
+  CHART_PREVIEW_CONTENT_STYLE,
+  CHART_PREVIEW_COHORT_LABELS,
+  CHART_PREVIEW_RISK_TIME_INTERVALS,
+  CHART_PREVIEW_KM_COLORS,
+  getChartPreviewContentStyle,
+  areChartsInteractionDisabled,
+  chartPreviewCohortName,
+  buildPlaceholderVennCohortData,
+  buildPlaceholderSurvivalRiskCohorts,
+} from '../../../utils/cohortAnalyzerChartPreview';
+
+describe('cohortAnalyzerChartPreview', () => {
+  describe('getChartPreviewContentStyle', () => {
+    it('returns style object in preview mode', () => {
+      expect(getChartPreviewContentStyle(true)).toEqual(CHART_PREVIEW_CONTENT_STYLE);
+    });
+
+    it('returns undefined when not in preview', () => {
+      expect(getChartPreviewContentStyle(false)).toBeUndefined();
+    });
+  });
+
+  describe('areChartsInteractionDisabled', () => {
+    it('is true when all inputs empty', () => {
+      expect(areChartsInteractionDisabled(true, false)).toBe(true);
+    });
+
+    it('is true in preview mode even with data', () => {
+      expect(areChartsInteractionDisabled(false, true)).toBe(true);
+    });
+
+    it('is false when cohorts selected and not preview', () => {
+      expect(areChartsInteractionDisabled(false, false)).toBe(false);
+    });
+  });
+
+  describe('chartPreviewCohortName', () => {
+    it('returns labels by index', () => {
+      expect(chartPreviewCohortName(0)).toBe('Cohort A');
+      expect(chartPreviewCohortName(2)).toBe('Cohort C');
+    });
+
+    it('returns empty string for out of range index', () => {
+      expect(chartPreviewCohortName(9)).toBe('');
+    });
+  });
+
+  describe('buildPlaceholderVennCohortData', () => {
+    it('returns three empty cohorts with labels', () => {
+      const data = buildPlaceholderVennCohortData();
+      expect(data).toHaveLength(3);
+      expect(data[0].cohortName).toBe(CHART_PREVIEW_COHORT_LABELS[0]);
+      expect(data[0].participants).toEqual([]);
+    });
+  });
+
+  describe('buildPlaceholderSurvivalRiskCohorts', () => {
+    it('returns cohort rows with ids and colors', () => {
+      const rows = buildPlaceholderSurvivalRiskCohorts();
+      expect(rows).toHaveLength(3);
+      expect(rows[0].id).toBe('c1');
+      expect(rows[0].data).toEqual({});
+      expect(CHART_PREVIEW_KM_COLORS).toHaveLength(3);
+    });
+  });
+
+  it('exports risk time intervals matching risk-table defaults', () => {
+    expect(CHART_PREVIEW_RISK_TIME_INTERVALS[0]).toBe('0 Months');
+    expect(CHART_PREVIEW_RISK_TIME_INTERVALS).toContain('36 Months');
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/vennDiagram/ChartVennConfig.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/vennDiagram/ChartVennConfig.test.js
@@ -1,0 +1,22 @@
+import { buildVennCohortSetLabel } from '../../../vennDiagram/ChartVennConfig';
+
+describe('ChartVennConfig', () => {
+  describe('buildVennCohortSetLabel', () => {
+    it('includes participant count by default', () => {
+      expect(buildVennCohortSetLabel('Cohort A', 12)).toBe('Cohort A (12)');
+    });
+
+    it('omits count when includeCount is false', () => {
+      expect(buildVennCohortSetLabel('Cohort A', 0, undefined, false)).toBe('Cohort A');
+    });
+
+    it('truncates long names with ellipsis', () => {
+      const long = 'A'.repeat(30);
+      expect(buildVennCohortSetLabel(long, 1, 10)).toBe(`${'A'.repeat(10)}… (1)`);
+    });
+
+    it('handles empty cohort name', () => {
+      expect(buildVennCohortSetLabel('', 0)).toBe(' (0)');
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/__tests__/unit/vennDiagram/chartVennColorUtils.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/vennDiagram/chartVennColorUtils.test.js
@@ -1,0 +1,43 @@
+import {
+  hexToRgba,
+  baseColorArray,
+  nodes,
+  VENN_CHART_LAYOUT_PADDING,
+  VENN_CANVAS_SIZE_SCALE,
+  VENN_COHORT_LABEL_GAP_PX,
+} from '../../../vennDiagram/ChartVennConfig';
+
+describe('ChartVennConfig color utilities', () => {
+  describe('hexToRgba', () => {
+    it('converts hex to rgba', () => {
+      expect(hexToRgba('#FF0000', 0.5)).toBe('rgba(255, 0, 0, 0.5)');
+    });
+
+    it('defaults alpha to 1', () => {
+      expect(hexToRgba('#00FF00')).toBe('rgba(0, 255, 0, 1)');
+    });
+  });
+
+  describe('baseColorArray', () => {
+    it('provides three cohort fill colors', () => {
+      expect(baseColorArray).toHaveLength(3);
+      baseColorArray.forEach((color) => {
+        expect(color).toMatch(/^rgba\(/);
+      });
+    });
+  });
+
+  describe('nodes', () => {
+    it('lists analyzer node keys', () => {
+      expect(nodes).toEqual(['participant_pk', 'diagnosis', 'treatment_type']);
+    });
+  });
+
+  describe('layout constants', () => {
+    it('defines chart padding and scale', () => {
+      expect(VENN_CHART_LAYOUT_PADDING.top).toBeDefined();
+      expect(VENN_CANVAS_SIZE_SCALE).toBeGreaterThan(1);
+      expect(VENN_COHORT_LABEL_GAP_PX).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/pages/CohortAnalyzer/cohortAnalyzerPageLogic.js
+++ b/src/pages/CohortAnalyzer/cohortAnalyzerPageLogic.js
@@ -1,0 +1,97 @@
+/**
+ * Pure page-level logic for Cohort Analyzer (unit-testable, no React hooks).
+ */
+
+const VENN_SECTION_NAME_REGEX = /(.*?)(?= \(\d+\))/;
+
+export function computeHasParticipantData(state, selectedCohorts) {
+  if (!state || !Array.isArray(selectedCohorts)) return false;
+  return selectedCohorts.some(
+    (id) => state[id]
+      && Array.isArray(state[id].participants)
+      && state[id].participants.length > 0,
+  );
+}
+
+export function getCohortAnalyzerTableMessage(cohortList, selectedCohortSection, tableConfig) {
+  if (cohortList.length === 0) {
+    return { noMatch: 'To proceed, please create your cohort by visiting the Explore Page.' };
+  }
+  if (selectedCohortSection.length === 0) {
+    return tableConfig.tableMsg;
+  }
+  return { noMatch: 'No data available for the selected segment/segments. Please try a different segment/segments.' };
+}
+
+export function extractCohortNameFromVennSection(section) {
+  const match = section.match(VENN_SECTION_NAME_REGEX);
+  return match ? match[1] : null;
+}
+
+export function filterVennSectionsForSelectedCohorts(
+  selectedCohortSection,
+  selectedCohorts,
+  nodeIndex,
+) {
+  if (nodeIndex !== 0 && nodeIndex !== 1 && nodeIndex !== 2) {
+    return [];
+  }
+  const finalVennSelection = [];
+  selectedCohortSection.forEach((section) => {
+    if (section.split(' ∩ ').length > 1) {
+      const validCohorts = [];
+      section.split(' ∩ ').forEach((sec) => {
+        const cohortName = extractCohortNameFromVennSection(sec);
+        if (cohortName && selectedCohorts.includes(cohortName)) {
+          validCohorts.push(sec);
+        }
+      });
+      if (validCohorts.length > 0) {
+        finalVennSelection.push(validCohorts.join(' ∩ '));
+      }
+    } else {
+      const cohortName = extractCohortNameFromVennSection(section);
+      if (cohortName && selectedCohorts.includes(cohortName)) {
+        finalVennSelection.push(section);
+      }
+    }
+  });
+  return finalVennSelection;
+}
+
+export function shouldClearRowDataOnEmptySelection(selectedCohorts, location) {
+  if (selectedCohorts.length !== 0) return false;
+  const hasNavigatedCohort = location
+    && location.state
+    && location.state.cohort
+    && location.state.cohort.cohortId;
+  return !hasNavigatedCohort;
+}
+
+export function countNonExampleCohorts(state, exampleCohortKeys) {
+  return Object.keys(state || {}).filter((key) => !exampleCohortKeys.includes(key));
+}
+
+export function canAddExampleCohorts(state, exampleCohortKeys, maxNonExample = 17) {
+  return countNonExampleCohorts(state, exampleCohortKeys).length <= maxNonExample;
+}
+
+export function buildExploreUploadPayload(rowData) {
+  const upload = rowData.map((r) => ({
+    participant_id: r.participant_id,
+    study_id: r.dbgap_accession,
+  }));
+  return {
+    upload,
+    uploadMetadata: {
+      filename: '',
+      fileContent: upload.map((p) => p.participant_id).join(','),
+      matched: upload,
+      unmatched: [],
+    },
+  };
+}
+
+export function shouldSkipNavigateAwayModal() {
+  return localStorage.getItem('hideNavigateModal') === 'true';
+}

--- a/src/pages/CohortAnalyzer/cohortAnalyzerPageLogic.js
+++ b/src/pages/CohortAnalyzer/cohortAnalyzerPageLogic.js
@@ -69,11 +69,11 @@ export function shouldClearRowDataOnEmptySelection(selectedCohorts, location) {
 }
 
 export function countNonExampleCohorts(state, exampleCohortKeys) {
-  return Object.keys(state || {}).filter((key) => !exampleCohortKeys.includes(key));
+  return Object.keys(state || {}).filter((key) => !exampleCohortKeys.includes(key)).length;
 }
 
 export function canAddExampleCohorts(state, exampleCohortKeys, maxNonExample = 17) {
-  return countNonExampleCohorts(state, exampleCohortKeys).length <= maxNonExample;
+  return countNonExampleCohorts(state, exampleCohortKeys) <= maxNonExample;
 }
 
 export function buildExploreUploadPayload(rowData) {

--- a/src/pages/CohortAnalyzer/styling/cohortAnalyzerThemeConfig.js
+++ b/src/pages/CohortAnalyzer/styling/cohortAnalyzerThemeConfig.js
@@ -21,14 +21,14 @@ export const cohortAnalyzerThemeConfig = {
                 borderBottom: '1px solid #000000',
             },
         },
-        // Left-align all column headers; first column keeps its larger 20px left gutter.
+        // Center all column headers; first column keeps link styling in body rows only.
         MuiTableCell: {
             ...(themeConfig.tblHeader && themeConfig.tblHeader.MuiTableCell),
             root: {
                 ...(themeConfig.tblHeader
                     && themeConfig.tblHeader.MuiTableCell
                     && themeConfig.tblHeader.MuiTableCell.root),
-                textAlign: 'left',
+                textAlign: 'center',
                 padding: '0px 8px',
                 // Column headers: Inter Bold, 17/17/0, Primary 4.
                 fontFamily: 'Inter, sans-serif',
@@ -37,12 +37,9 @@ export const cohortAnalyzerThemeConfig = {
                 lineHeight: '17px',
                 letterSpacing: '0',
                 color: PRIMARY_4,
-                '&:first-of-type': {
-                    paddingLeft: '20px',
-                },
             },
         },
-        // Sort label container — left-justify in every column.
+        // Sort label container — center in every column.
         // Inherit the cell's Inter Bold typography so the sortable header label matches the spec.
         MuiTableSortLabel: {
             ...(themeConfig.tblHeader && themeConfig.tblHeader.MuiTableSortLabel),
@@ -50,7 +47,7 @@ export const cohortAnalyzerThemeConfig = {
                 ...(themeConfig.tblHeader
                     && themeConfig.tblHeader.MuiTableSortLabel
                     && themeConfig.tblHeader.MuiTableSortLabel.root),
-                justifyContent: 'flex-start',
+                justifyContent: 'center',
                 width: '100%',
                 fontFamily: 'Inter, sans-serif',
                 fontWeight: 700,
@@ -67,7 +64,7 @@ export const cohortAnalyzerThemeConfig = {
             ...themeConfig.tblBody.MuiTableCell,
             body: {
                 ...themeConfig.tblBody.MuiTableCell.body,
-                textAlign: 'left',
+                textAlign: 'center',
                 paddingLeft: '8px',
                 paddingRight: '8px',
                 // Table text: Inter Regular, 16/17/0, Primary 4.
@@ -81,7 +78,6 @@ export const cohortAnalyzerThemeConfig = {
                     // Table text links: Inter Semibold, 16/17/0, Purple 1.
                     color: PURPLE_1,
                     textDecoration: 'underline',
-                    paddingLeft: '20px',
                     fontWeight: 600,
                 },
             },

--- a/src/pages/CohortAnalyzer/styling/layoutStyles.js
+++ b/src/pages/CohortAnalyzer/styling/layoutStyles.js
@@ -1,8 +1,8 @@
 /** Cohort sidebar, table shell, main analyzer column, and grid wrappers. */
 export const cohortAnalyzerLayoutStyles = (theme) => ({
   leftSideAnalyzer: {
-    minWidth: 268,
-    maxWidth: 268,
+    minWidth: 274,
+    maxWidth: 274,
     height: 588,
     marginTop: 40,
     overflow: 'hidden',
@@ -133,9 +133,11 @@ export const cohortAnalyzerLayoutStyles = (theme) => ({
   sortSection: {
     height: 31,
     width: '100%',
+    boxSizing: 'border-box',
     display: 'flex',
     justifyContent: 'space-between',
-    marginLeft: 20,
+    paddingLeft: 20,
+    backgroundColor: '#F1F1F1',
     '& p': {
       fontSize: 9,
     },

--- a/src/pages/CohortAnalyzer/testSupport/cohortAnalyzerMocks.js
+++ b/src/pages/CohortAnalyzer/testSupport/cohortAnalyzerMocks.js
@@ -1,0 +1,57 @@
+/**
+ * Shared mocks for Cohort Analyzer tests. Import and call resetCohortAnalyzerMocks() in beforeEach.
+ */
+
+export const mockNavigate = jest.fn();
+export const mockDispatch = jest.fn();
+export const mockNotificationShow = jest.fn();
+export const mockGetJoinedCohortData = jest.fn(() => Promise.resolve());
+export const mockOpenUserGuide = jest.fn();
+
+export const defaultCohortAnalyzerContext = {
+  resetVennWorkspaceUi: jest.fn(),
+  selectedCohorts: [],
+  setSelectedCohorts: jest.fn(),
+  cohortList: [],
+  setCohortList: jest.fn(),
+  nodeIndex: 0,
+  cohortData: null,
+  setCohortData: jest.fn(),
+  generalInfo: {},
+  setGeneralInfo: jest.fn(),
+  rowData: [],
+  setRowData: jest.fn(),
+  setRefreshTableContent: jest.fn(),
+  searchValue: '',
+  setSearchValue: jest.fn(),
+  setQueryVariable: jest.fn(),
+  selectedChart: [],
+  selectedCohortSection: [],
+  setSelectedCohortSections: jest.fn(),
+  setDeleteInfo: jest.fn(),
+  deleteInfo: { showDeleteConfirmation: false, deleteType: '', cohortId: '' },
+  handleCheckbox: jest.fn(),
+  showNavigateAwayModal: false,
+  setShowNavigateAwayModal: jest.fn(),
+  setAlert: jest.fn(),
+  alert: { type: '', message: '' },
+};
+
+export const defaultCohortState = {
+  'cohort-a': {
+    cohortId: 'cohort-a',
+    cohortName: 'Cohort A',
+    participants: [{ id: 'p1', participant: { id: 'p1' }, participant_pk: 'pk1' }],
+  },
+};
+
+export function resetCohortAnalyzerMocks() {
+  mockNavigate.mockClear();
+  mockDispatch.mockClear();
+  mockNotificationShow.mockClear();
+  mockGetJoinedCohortData.mockClear();
+  mockOpenUserGuide.mockClear();
+  Object.values(defaultCohortAnalyzerContext).forEach((fn) => {
+    if (typeof fn === 'function' && fn.mockClear) fn.mockClear();
+  });
+}

--- a/src/pages/CohortAnalyzer/testSupport/cohortAnalyzerTestUtils.js
+++ b/src/pages/CohortAnalyzer/testSupport/cohortAnalyzerTestUtils.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+
+/**
+ * Minimal Redux store for Cohort Analyzer layout slice tests / component renders.
+ */
+export function createCohortAnalyzerTestStore(layoutOverrides = {}) {
+  const initialState = {
+    cohortAnalyzerLayout: {
+      topRowOrder: ['venn', 'survival'],
+      panelRegistry: {},
+      sizes: {},
+      stripOrder: [],
+      besideStripPanelId: null,
+      chartVisualByPanelId: {},
+      userLayoutChanged: false,
+      ...layoutOverrides,
+    },
+  };
+  return createStore((state = initialState) => state);
+}
+
+export function renderWithCohortAnalyzerProviders(ui, { route = '/', store } = {}) {
+  const testStore = store || createCohortAnalyzerTestStore();
+  return render(
+    <Provider store={testStore}>
+      <MemoryRouter
+        initialEntries={[route]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        {ui}
+      </MemoryRouter>
+    </Provider>,
+  );
+}


### PR DESCRIPTION
## Summary

Adds a focused Jest test suite for the Cohort Analyzer module, along with the supporting tooling and small refactors needed to keep business logic testable without rendering full chart/table UIs.

Also includes merged design QA updates for the cohort selector sidebar and participant table alignment.

## What's included

- **~30 unit test suites** under `src/pages/CohortAnalyzer/__tests__/`, organized by feature area (store, config, utilities, components, downloads, etc.)
- **Page entry-point tests** for `CohortAnalyzer.js` wiring (handlers, effects, modals) using shared mocks—not full integration with live child components
- **`cohortAnalyzerPageLogic.js`** — pure helpers extracted from the page component for direct unit testing
- **Shared test support** (`testSupport/`, `config/jest/setupTests.js`) and **`npm run test:cohort-analyzer`** for 



