### PR TITLE
Design QA Round-3

### DIFF
--- a/src/components/Notifications/NotifactionView.js
+++ b/src/components/Notifications/NotifactionView.js
@@ -18,16 +18,19 @@ const useStyles = makeStyles(() => ({
   },
   alertStyles: {
     // Widths & Size
-    width: '235px',
+    width: (props) => props.width || '235px',
+    maxWidth: (props) => props.width || '235px',
     minHeight: '50px',
     boxSizing: 'border-box',
-    
+    display: 'flex',
+    padding: (props) => (props.textAlign === 'left' ? '12px 16px' : '6px 16px'),
 
     // Fonts
     color: '#ffffff',
     fontFamily: 'Nunito',
     textAlign: (props) => props.textAlign || 'center',
-    justifyContent: 'center',
+    justifyContent: (props) => (props.textAlign === 'left' ? 'flex-start' : 'center'),
+    alignItems: (props) => (props.textAlign === 'left' ? 'flex-start' : 'center'),
     fontSize: '16px',
     fontWeight: '300',
     letterSpacing: '0',
@@ -41,15 +44,36 @@ const useStyles = makeStyles(() => ({
 
     // Positioning
     zIndex: '1100',
+
+    '& .MuiAlert-message': {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: (props) => (props.textAlign === 'left' ? 'flex-start' : 'center'),
+      justifyContent: (props) => (props.textAlign === 'left' ? 'flex-start' : 'center'),
+      textAlign: (props) => props.textAlign || 'center',
+      width: '100%',
+      margin: 0,
+      padding: 0,
+    },
+  },
+  notificationIcon: {
+    flexShrink: 0,
+    display: 'block',
+    marginRight: (props) => (props.textAlign === 'left' ? 10 : 8),
+  },
+  notificationMessage: {
+    flex: 1,
+    whiteSpace: 'pre-line',
+    textAlign: (props) => props.textAlign || 'center',
   },
 }));
 
 const NotificationView = () => {
   const { Notification } = useGlobal();
   const {
-    open, message, duration, location,
+    open, message, duration, location, styleOptions,
   } = Notification.getProps();
-  const classes = useStyles();
+  const classes = useStyles(styleOptions || {});
 
   const { vertical, horizontal } = location;
 
@@ -67,8 +91,8 @@ const NotificationView = () => {
         onClose={handleClose}
       >
         <Alert severity="success" icon={false} className={classes.alertStyles}>
-          <img src={SuccessOutlined} alt="" />
-          {message}
+          <img src={SuccessOutlined} alt="" className={classes.notificationIcon} />
+          <span className={classes.notificationMessage}>{message}</span>
         </Alert>
       </Snackbar>
     </div>

--- a/src/components/Notifications/NotificationFunctions.js
+++ b/src/components/Notifications/NotificationFunctions.js
@@ -10,8 +10,7 @@ const NotificationFunctions = () => {
     vertical: 'bottom',
     horizontal: 'right',
   });
-
-  // Variables
+  const [styleOptions, setStyleOptions] = React.useState({});
 
   // Methods for Notifications.
   const close = (event, reason) => {
@@ -20,16 +19,19 @@ const NotificationFunctions = () => {
     }
 
     setOpen(false);
+    setStyleOptions({});
   };
 
-  const show = (msg, timeoutDuration) => {
+  /** @param {string} msg @param {number} [timeoutDuration] @param {{ width?: string, textAlign?: 'left'|'center'|'right' }} [options] */
+  const show = (msg, timeoutDuration, options = {}) => {
     setMessage(msg);
     setDuration(timeoutDuration);
+    setStyleOptions(options);
     setOpen(true);
   };
 
   const getProps = () => ({
-    open, duration, message, location,
+    open, duration, message, location, styleOptions,
   });
 
   return {

--- a/src/pages/CohortAnalyzer/CohortAnalyzer.js
+++ b/src/pages/CohortAnalyzer/CohortAnalyzer.js
@@ -273,7 +273,11 @@ export const CohortAnalyzer = () => {
             if (successCount === totalCohorts) {
                 // Auto-select the newly created example cohorts
                 setSelectedCohorts(getExampleCohortKeys());
-                Notification.show(`Successfully created and selected ${totalCohorts} example cohorts! View the results in the Venn diagram and histogram below.`, 7000);
+                Notification.show(
+                    `Successfully created and selected ${totalCohorts} example cohorts!\nView the results in the Venn diagram and histogram below.`,
+                    7000,
+                    { width: '400px', textAlign: 'left' },
+                );
             }
         };
 

--- a/src/pages/CohortAnalyzer/CohortAnalyzerTableSection/CohortAnalyzerTableSection.js
+++ b/src/pages/CohortAnalyzer/CohortAnalyzerTableSection/CohortAnalyzerTableSection.js
@@ -7,7 +7,7 @@ import { useCohortAnalyzer } from '../context/CohortAnalyzerContext';
 import { ButtonWithTooltip } from './ButtonWithTooltip';
 
 const row = { display: 'flex', alignItems: 'center' };
-const bar = { display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 12, flexWrap: 'wrap' };
+const bar = { display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: '26px', flexWrap: 'wrap' };
 
 
 const CohortAnalyzerTableSection = ({ classes, questionIcon, handleClick, handleBuildInExplore, themeConfig, initTblState }) => {

--- a/src/pages/CohortAnalyzer/CreateNewCohortButton/CreateNewCohortButton.js
+++ b/src/pages/CohortAnalyzer/CreateNewCohortButton/CreateNewCohortButton.js
@@ -23,9 +23,9 @@ export const CreateNewCohortButton = ({ selectedCohortSection, questionIcon, row
 
             <ToolTip title={"Click to create a new cohort based on these analysis results."} arrow placement="top">
                 <div
-                    style={{ textAlign: 'right', marginLeft: 5}}
+                    style={{ textAlign: 'right', marginLeft: '4px'}}
                 >
-                    <img alt={"Question Icon"} src={questionIcon} width={10} style={{ fontSize: 10, position: 'relative', top: -5, left: -3 }} />
+                    <img alt={"Question Icon"} src={questionIcon} width={10} style={{ fontSize: 10, position: 'relative', top: -5, left: 0 }} />
                 </div>
             </ToolTip>
         </div>
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
         color: 'white',
         fontFamily: "Poppins",
         fontSize: "12px",
-        fontWeight: 600,
+        fontWeight: 500,
         cursor: 'pointer',
     },
     createCohortOpacity: {
@@ -59,7 +59,7 @@ const useStyles = makeStyles((theme) => ({
         backgroundColor: "#55646766",
         fontFamily: "Poppins",
         fontSize: "12px",
-        fontWeight: 900,
+        fontWeight: 500,
         border: '1.25px solid #0000001A',
     },
 }));

--- a/src/pages/CohortAnalyzer/HistogramPanel/Histogram.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/Histogram.js
@@ -512,6 +512,7 @@ const Histogram = ({
                   ...stripVennChartWrapperStyle,
                   ...chartPreviewStyle,
                   cursor: 'default',
+                  overflow: 'hidden',
                 }}
                 draggable={false}
                 onDragOver={(e) => handleStripChartDragOver(e, 'venn')}

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/CustomXAxisTick.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/CustomXAxisTick.js
@@ -2,7 +2,18 @@ import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import CustomChartTooltip from './CustomChartTooltip';
 
-const CustomXAxisTick = ({ x, y, payload, width, fontSize = 8, lineHeight = fontSize, letterSpacing = 0 }) => {
+const CustomXAxisTick = ({
+  x,
+  y,
+  payload,
+  width,
+  fontSize = 8,
+  lineHeight = fontSize,
+  letterSpacing = 0,
+  fill = '#333',
+  fontFamily = 'Nunito',
+  fontWeight = 500,
+}) => {
   const [showTooltip, setShowTooltip] = useState(false);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
 
@@ -87,12 +98,14 @@ const CustomXAxisTick = ({ x, y, payload, width, fontSize = 8, lineHeight = font
             y={index * (lineHeight + 2)}
             dy={16}
             textAnchor="middle"
-            fill="#333"
+            fill={fill}
             fontSize={fontSize}
+            fontFamily={fontFamily}
+            fontWeight={fontWeight}
             style={{
-              pointerEvents: isTruncated ? 'none' : 'auto',  // Disable pointer events on text when using rect
+              pointerEvents: isTruncated ? 'none' : 'auto',
               letterSpacing: `${letterSpacing}px`,
-              lineHeight: `${lineHeight}px`
+              lineHeight: `${lineHeight}px`,
             }}
           >
             {/* Add title to each text element as well for better browser support */}

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/CustomXAxisTick.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/CustomXAxisTick.js
@@ -17,7 +17,7 @@ const CustomXAxisTick = ({ x, y, payload, width, fontSize = 8, lineHeight = font
 
   // Calculate max characters based on available width
   // Approximate that each character takes about 6-7 pixels at fontSize 8, 7-8 at fontSize 10
-  const charWidth = fontSize === 8 ? 4 : 5;
+  const charWidth = fontSize <= 8 ? 4 : fontSize <= 11 ? 5 : Math.ceil(fontSize * 0.54);
   const maxLength = width ? Math.floor(width / charWidth) : 10;
 
   // Function to truncate text
@@ -73,7 +73,7 @@ const CustomXAxisTick = ({ x, y, payload, width, fontSize = 8, lineHeight = font
             x={-width / 2}  // Center the rectangle
             y={0}
             width={width}
-            height={lines.length * 12 + 20}  // Cover all lines plus some padding
+            height={lines.length * (lineHeight + 2) + 20}
             fill="transparent"
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
@@ -84,7 +84,7 @@ const CustomXAxisTick = ({ x, y, payload, width, fontSize = 8, lineHeight = font
           <text
             key={index}
             x={0}
-            y={index * 12}
+            y={index * (lineHeight + 2)}
             dy={16}
             textAnchor="middle"
             fill="#333"

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
@@ -15,6 +15,7 @@ import {
 } from 'recharts';
 import CustomChartTooltip from './CustomChartTooltip';
 import CustomXAxisTick from './CustomXAxisTick';
+import { HISTOGRAM_EXPANDED_AXIS_FONT_SIZE } from '../histogramConstants';
 import { barColors } from '../HistogramPanel.styled';
 
 export const CHART_TYPE_KEYS = {
@@ -70,7 +71,7 @@ const PieChartTooltip = ({ active, payload, viewType }) => {
   );
 };
 
-const yAxisTickStyle = {
+const DEFAULT_Y_AXIS_TICK_STYLE = {
   fontSize: 11,
   fill: '#666666',
   fontFamily: 'Nunito',
@@ -78,6 +79,30 @@ const yAxisTickStyle = {
   lineHeight: 11,
   letterSpacing: 0,
 };
+
+const buildYAxisTickStyle = (expandedView) => (
+  expandedView
+    ? {
+      ...DEFAULT_Y_AXIS_TICK_STYLE,
+      fontSize: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
+      lineHeight: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
+    }
+    : DEFAULT_Y_AXIS_TICK_STYLE
+);
+
+const buildXTickProps = (expandedView, compact) => (
+  expandedView
+    ? {
+      fontSize: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
+      lineHeight: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
+      letterSpacing: 0,
+    }
+    : {
+      fontSize: compact ? 10 : 10,
+      lineHeight: compact ? 10 : 11,
+      letterSpacing: 0,
+    }
+);
 
 function buildPieData(rows) {
   return rows
@@ -115,7 +140,18 @@ export function HistogramDatasetChart({
   c2Name = 'Cohort B',
   c3Name = 'Cohort C',
   previewShell = false,
+  expandedView = false,
 }) {
+  const yAxisTickStyle = buildYAxisTickStyle(expandedView);
+  const xTickProps = buildXTickProps(expandedView, compact);
+  const categoryAxisTickStyle = {
+    fontSize: expandedView ? HISTOGRAM_EXPANDED_AXIS_FONT_SIZE : 10,
+    fill: '#666666',
+    fontFamily: 'Nunito',
+    fontWeight: 500,
+    lineHeight: expandedView ? HISTOGRAM_EXPANDED_AXIS_FONT_SIZE : 10,
+    letterSpacing: 0,
+  };
   const bottomMargin = compact ? 12 : 0;
   const yAxisTickFormatter = (value) => {
     const num = Number(value);
@@ -143,12 +179,6 @@ export function HistogramDatasetChart({
   };
 
   const pieMargin = { top: 8, right: 8, left: 8, bottom: 8 };
-
-  const xTickProps = {
-    fontSize: compact ? 10 : 10,
-    lineHeight: compact ? 10 : 11,
-    letterSpacing: 0,
-  };
 
   if (previewShell) {
     const shellMargin = {
@@ -290,7 +320,7 @@ export function HistogramDatasetChart({
             dataKey="name"
             type="category"
             width={compact ? 90 : 110}
-            tick={{ fontSize: 10, fill: '#666666', fontFamily: 'Nunito' }}
+            tick={categoryAxisTickStyle}
             tickFormatter={(v) => formatCategoryLabel(v)}
           />
           <Tooltip content={<MultiseriesTooltip viewType={viewType} />} />

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
@@ -93,7 +93,7 @@ const buildXTickProps = (expandedView, compact) => (
   expandedView
     ? { ...HISTOGRAM_EXPANDED_AXIS_TICK_PROPS }
     : {
-      fontSize: compact ? 10 : 10,
+      fontSize: 10,
       lineHeight: compact ? 10 : 11,
       letterSpacing: 0,
     }

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
@@ -15,7 +15,7 @@ import {
 } from 'recharts';
 import CustomChartTooltip from './CustomChartTooltip';
 import CustomXAxisTick from './CustomXAxisTick';
-import { HISTOGRAM_EXPANDED_AXIS_FONT_SIZE } from '../histogramConstants';
+import { HISTOGRAM_CHART_STROKE_COLOR, HISTOGRAM_EXPANDED_AXIS_TICK_PROPS } from '../histogramConstants';
 import { barColors } from '../HistogramPanel.styled';
 
 export const CHART_TYPE_KEYS = {
@@ -26,6 +26,9 @@ export const CHART_TYPE_KEYS = {
 };
 
 export const DEFAULT_CHART_TYPE = CHART_TYPE_KEYS.VERTICAL_BAR;
+
+const chartAxisLine = { stroke: HISTOGRAM_CHART_STROKE_COLOR };
+const chartTickLine = { stroke: HISTOGRAM_CHART_STROKE_COLOR };
 
 const tooltipBox = {
   backgroundColor: 'white',
@@ -82,21 +85,13 @@ const DEFAULT_Y_AXIS_TICK_STYLE = {
 
 const buildYAxisTickStyle = (expandedView) => (
   expandedView
-    ? {
-      ...DEFAULT_Y_AXIS_TICK_STYLE,
-      fontSize: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
-      lineHeight: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
-    }
+    ? { ...HISTOGRAM_EXPANDED_AXIS_TICK_PROPS }
     : DEFAULT_Y_AXIS_TICK_STYLE
 );
 
 const buildXTickProps = (expandedView, compact) => (
   expandedView
-    ? {
-      fontSize: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
-      lineHeight: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
-      letterSpacing: 0,
-    }
+    ? { ...HISTOGRAM_EXPANDED_AXIS_TICK_PROPS }
     : {
       fontSize: compact ? 10 : 10,
       lineHeight: compact ? 10 : 11,
@@ -144,14 +139,16 @@ export function HistogramDatasetChart({
 }) {
   const yAxisTickStyle = buildYAxisTickStyle(expandedView);
   const xTickProps = buildXTickProps(expandedView, compact);
-  const categoryAxisTickStyle = {
-    fontSize: expandedView ? HISTOGRAM_EXPANDED_AXIS_FONT_SIZE : 10,
-    fill: '#666666',
-    fontFamily: 'Nunito',
-    fontWeight: 500,
-    lineHeight: expandedView ? HISTOGRAM_EXPANDED_AXIS_FONT_SIZE : 10,
-    letterSpacing: 0,
-  };
+  const categoryAxisTickStyle = expandedView
+    ? { ...HISTOGRAM_EXPANDED_AXIS_TICK_PROPS }
+    : {
+      fontSize: 10,
+      fill: '#666666',
+      fontFamily: 'Nunito',
+      fontWeight: 500,
+      lineHeight: 10,
+      letterSpacing: 0,
+    };
   const bottomMargin = compact ? 12 : 0;
   const yAxisTickFormatter = (value) => {
     const num = Number(value);
@@ -190,18 +187,21 @@ export function HistogramDatasetChart({
     return (
       <ResponsiveContainer width={width} height={height}>
         <BarChart data={[{ name: ' ' }]} margin={shellMargin}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" horizontal vertical={false} />
+          <CartesianGrid strokeDasharray="3 3" stroke={HISTOGRAM_CHART_STROKE_COLOR} horizontal vertical={false} />
           <XAxis
             dataKey="name"
             interval={0}
             tick={false}
-            axisLine={{ stroke: '#e0e0e0' }}
+            axisLine={chartAxisLine}
+            tickLine={chartTickLine}
             height={xAxisHeight}
           />
           <YAxis
             domain={[0, 100]}
             tickFormatter={yAxisTickFormatter}
             tick={yAxisTickStyle}
+            axisLine={chartAxisLine}
+            tickLine={chartTickLine}
           />
         </BarChart>
       </ResponsiveContainer>
@@ -238,7 +238,7 @@ export function HistogramDatasetChart({
             cx="50%"
             cy="50%"
             outerRadius={Math.min(height, estimatedChartWidth) * 0.36}
-            stroke="#000"
+            stroke={HISTOGRAM_CHART_STROKE_COLOR}
             strokeWidth={0.5}
           >
             {pieData.map((entry, i) => (
@@ -255,13 +255,15 @@ export function HistogramDatasetChart({
     return (
       <ResponsiveContainer width={width} height={height}>
         <LineChart data={rows} margin={lineMargin}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" horizontal vertical={false} />
+          <CartesianGrid strokeDasharray="3 3" stroke={HISTOGRAM_CHART_STROKE_COLOR} horizontal vertical={false} />
           <XAxis
             dataKey="name"
             interval={0}
             angle={0}
             textAnchor="middle"
             height={xAxisHeight}
+            axisLine={chartAxisLine}
+            tickLine={chartTickLine}
             tick={(props) => (
               <CustomXAxisTick {...props} width={availableWidth} {...xTickProps} />
             )}
@@ -270,6 +272,8 @@ export function HistogramDatasetChart({
             domain={[0, 'dataMax']}
             tickFormatter={yAxisTickFormatter}
             tick={yAxisTickStyle}
+            axisLine={chartAxisLine}
+            tickLine={chartTickLine}
           />
           <Tooltip content={<MultiseriesTooltip viewType={viewType} />} />
           {valueA > 0 && (
@@ -279,7 +283,7 @@ export function HistogramDatasetChart({
               name={c1Name}
               stroke={barColors.colorA}
               strokeWidth={2}
-              dot={{ r: 3, strokeWidth: 1, stroke: '#333', fill: barColors.colorA }}
+              dot={{ r: 3, strokeWidth: 1, stroke: HISTOGRAM_CHART_STROKE_COLOR, fill: barColors.colorA }}
               activeDot={{ r: 4 }}
             />
           )}
@@ -290,7 +294,7 @@ export function HistogramDatasetChart({
               name={c2Name}
               stroke={barColors.colorB}
               strokeWidth={2}
-              dot={{ r: 3, strokeWidth: 1, stroke: '#333', fill: barColors.colorB }}
+              dot={{ r: 3, strokeWidth: 1, stroke: HISTOGRAM_CHART_STROKE_COLOR, fill: barColors.colorB }}
               activeDot={{ r: 4 }}
             />
           )}
@@ -301,7 +305,7 @@ export function HistogramDatasetChart({
               name={c3Name}
               stroke={barColors.colorC}
               strokeWidth={2}
-              dot={{ r: 3, strokeWidth: 1, stroke: '#333', fill: barColors.colorC }}
+              dot={{ r: 3, strokeWidth: 1, stroke: HISTOGRAM_CHART_STROKE_COLOR, fill: barColors.colorC }}
               activeDot={{ r: 4 }}
             />
           )}
@@ -314,18 +318,27 @@ export function HistogramDatasetChart({
     return (
       <ResponsiveContainer width={width} height={height}>
         <BarChart layout="vertical" data={rows} margin={horizontalBarMargin}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" horizontal vertical={false} />
-          <XAxis type="number" domain={[0, 'dataMax']} tickFormatter={yAxisTickFormatter} tick={yAxisTickStyle} />
+          <CartesianGrid strokeDasharray="3 3" stroke={HISTOGRAM_CHART_STROKE_COLOR} horizontal vertical={false} />
+          <XAxis
+            type="number"
+            domain={[0, 'dataMax']}
+            tickFormatter={yAxisTickFormatter}
+            tick={yAxisTickStyle}
+            axisLine={chartAxisLine}
+            tickLine={chartTickLine}
+          />
           <YAxis
             dataKey="name"
             type="category"
             width={compact ? 90 : 110}
             tick={categoryAxisTickStyle}
             tickFormatter={(v) => formatCategoryLabel(v)}
+            axisLine={chartAxisLine}
+            tickLine={chartTickLine}
           />
           <Tooltip content={<MultiseriesTooltip viewType={viewType} />} />
           {valueA > 0 && (
-            <Bar dataKey="valueA" name="Cohort A" maxBarSize={28} stroke="#000" strokeWidth={0.6}>
+            <Bar dataKey="valueA" name="Cohort A" maxBarSize={28} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
               {rows.map((entry, entryIndex) => (
                 <Cell
                   key={`hbar-a-${entryIndex}`}
@@ -337,7 +350,7 @@ export function HistogramDatasetChart({
             </Bar>
           )}
           {valueB > 0 && (
-            <Bar dataKey="valueB" name="Cohort B" maxBarSize={28} stroke="#000" strokeWidth={0.6}>
+            <Bar dataKey="valueB" name="Cohort B" maxBarSize={28} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
               {rows.map((entry, entryIndex) => (
                 <Cell
                   key={`hbar-b-${entryIndex}`}
@@ -349,7 +362,7 @@ export function HistogramDatasetChart({
             </Bar>
           )}
           {valueC > 0 && (
-            <Bar dataKey="valueC" name="Cohort C" maxBarSize={28} stroke="#000" strokeWidth={0.6}>
+            <Bar dataKey="valueC" name="Cohort C" maxBarSize={28} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
               {rows.map((entry, entryIndex) => (
                 <Cell
                   key={`hbar-c-${entryIndex}`}
@@ -369,21 +382,29 @@ export function HistogramDatasetChart({
   return (
     <ResponsiveContainer width={width} height={height}>
       <BarChart data={rows} margin={verticalBarMargin}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" horizontal vertical={false} />
+        <CartesianGrid strokeDasharray="3 3" stroke={HISTOGRAM_CHART_STROKE_COLOR} horizontal vertical={false} />
         <XAxis
           dataKey="name"
           interval={0}
           angle={0}
           textAnchor="middle"
           height={xAxisHeight}
+          axisLine={chartAxisLine}
+          tickLine={chartTickLine}
           tick={(props) => (
             <CustomXAxisTick {...props} width={availableWidth} {...xTickProps} />
           )}
         />
-        <YAxis domain={[0, 'dataMax']} tickFormatter={yAxisTickFormatter} tick={yAxisTickStyle} />
+        <YAxis
+          domain={[0, 'dataMax']}
+          tickFormatter={yAxisTickFormatter}
+          tick={yAxisTickStyle}
+          axisLine={chartAxisLine}
+          tickLine={chartTickLine}
+        />
         <Tooltip content={<CustomChartTooltip viewType={viewType} cellHoverRef={cellHover} />} />
         {valueA > 0 && (
-          <Bar dataKey="valueA" maxBarSize={60} stroke="#000" strokeWidth={0.6}>
+          <Bar dataKey="valueA" maxBarSize={60} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
             {rows.map((entry, entryIndex) => (
               <Cell
                 key={`vbar-a-${entryIndex}`}
@@ -395,7 +416,7 @@ export function HistogramDatasetChart({
           </Bar>
         )}
         {valueB > 0 && (
-          <Bar dataKey="valueB" maxBarSize={60} stroke="#000" strokeWidth={0.6}>
+          <Bar dataKey="valueB" maxBarSize={60} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
             {rows.map((entry, entryIndex) => (
               <Cell
                 key={`vbar-b-${entryIndex}`}
@@ -407,7 +428,7 @@ export function HistogramDatasetChart({
           </Bar>
         )}
         {valueC > 0 && (
-          <Bar dataKey="valueC" maxBarSize={60} stroke="#000" strokeWidth={0.6}>
+          <Bar dataKey="valueC" maxBarSize={60} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
             {rows.map((entry, entryIndex) => (
               <Cell
                 key={`vbar-c-${entryIndex}`}

--- a/src/pages/CohortAnalyzer/HistogramPanel/histogramConstants.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/histogramConstants.js
@@ -24,3 +24,6 @@ export const MAX_BARS_DISPLAYED_EXPANDED = 21;
 
 /** `activeTab` / `expandedChart` value for Venn in the shared ExpandedChartModal. */
 export const CA_EXPANDED_CHART_MODAL_TAB_VENN = 'venn';
+
+/** X/Y axis tick label size (px) for histogram + survival charts in the expanded modal. */
+export const HISTOGRAM_EXPANDED_AXIS_FONT_SIZE = 13;

--- a/src/pages/CohortAnalyzer/HistogramPanel/histogramConstants.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/histogramConstants.js
@@ -27,3 +27,19 @@ export const CA_EXPANDED_CHART_MODAL_TAB_VENN = 'venn';
 
 /** X/Y axis tick label size (px) for histogram + survival charts in the expanded modal. */
 export const HISTOGRAM_EXPANDED_AXIS_FONT_SIZE = 13;
+export const HISTOGRAM_EXPANDED_AXIS_TICK_COLOR = '#666666';
+export const HISTOGRAM_EXPANDED_AXIS_FONT_FAMILY = 'Nunito';
+export const HISTOGRAM_EXPANDED_AXIS_FONT_WEIGHT = 500;
+
+/** Shared Recharts tick props for histogram/survival charts in {@link HistogramPopup}. */
+export const HISTOGRAM_EXPANDED_AXIS_TICK_PROPS = {
+  fontSize: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
+  lineHeight: HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
+  letterSpacing: 0,
+  fill: HISTOGRAM_EXPANDED_AXIS_TICK_COLOR,
+  fontFamily: HISTOGRAM_EXPANDED_AXIS_FONT_FAMILY,
+  fontWeight: HISTOGRAM_EXPANDED_AXIS_FONT_WEIGHT,
+};
+
+/** Grid, axis, and shape outline color for histogram and survival charts in this panel. */
+export const HISTOGRAM_CHART_STROKE_COLOR = '#CCCCCC';

--- a/src/pages/CohortAnalyzer/HistogramPanel/hooks/useHistogramData.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/hooks/useHistogramData.js
@@ -67,13 +67,32 @@ export const useHistogramData = ({
     );
   };
 
+  const resolveHistogramChartRoot = (dataset, isExpanded) => {
+    if (isExpanded) {
+      return document.getElementById(`expanded-chart-${dataset}`);
+    }
+    return (
+      document.getElementById(`chart-${dataset}`)
+      || document.getElementById(`chart-beside-${dataset}`)
+    );
+  };
+
+  /** Recharts plot SVG only — excludes header chart-type icon SVGs. */
+  const findHistogramPlotSvg = (root) => {
+    if (!root) return null;
+    return (
+      root.querySelector('svg.recharts-surface')
+      || root.querySelector('.recharts-wrapper svg')
+      || null
+    );
+  };
+
   const downloadChart = (dataset, isExpanded) => {
     try {
-      const elementId = isExpanded ? `expanded-chart-${dataset}` : `chart-${dataset}`;
-      const chartElement = document.getElementById(elementId);
+      const chartElement = resolveHistogramChartRoot(dataset, isExpanded);
       if (!chartElement) return;
 
-      const svgElement = chartElement.querySelector("svg");
+      const svgElement = findHistogramPlotSvg(chartElement);
       if (!svgElement) return;
 
       const scaleFactor = 2;
@@ -104,7 +123,7 @@ export const useHistogramData = ({
           const downloadUrl = URL.createObjectURL(blob);
           const a = document.createElement("a");
           a.href = downloadUrl;
-          a.download = `data_chart.png`;
+          a.download = `${dataset}_chart.png`;
           document.body.appendChild(a);
           a.click();
           document.body.removeChild(a);

--- a/src/pages/CohortAnalyzer/HistogramPanel/popup/HistogramPopup.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/popup/HistogramPopup.js
@@ -225,8 +225,9 @@ const ExpandedChartModal = ({
     () => createHistogramModalSurvivalDownloads({
       setShowDownloadDropdown,
       survivalAnalysisContainerRef,
+      riskTableRef,
     }),
-    [survivalAnalysisContainerRef],
+    [survivalAnalysisContainerRef, riskTableRef],
   );
 
   let valueA = 0;

--- a/src/pages/CohortAnalyzer/HistogramPanel/popup/HistogramPopupModalHistogramTab.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/popup/HistogramPopupModalHistogramTab.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import {
   RadioInput,
-  RadioLabel,
   ModalChartContainer,
   ModalHistogramChartInset,
   ModalRadioFieldset,
   ModalRadioGroup,
+  ModalRadioLabel,
   ModalNoDataContainer,
 } from '../HistogramPanel.styled';
 import { HistogramDatasetChart, DEFAULT_CHART_TYPE } from '../chart/HistogramDatasetChart';
@@ -35,7 +35,7 @@ export function HistogramPopupModalHistogramTab({
     <ModalChartContainer>
       <ModalRadioFieldset>
         <ModalRadioGroup>
-          <RadioLabel>
+          <ModalRadioLabel>
             <RadioInput
               type="radio"
               name={`modalViewType-${activeTab}`}
@@ -43,11 +43,9 @@ export function HistogramPopupModalHistogramTab({
               checked={viewType[activeTab] === 'count'}
               onChange={(e) => setViewType((prev) => ({ ...prev, [activeTab]: e.target.value }))}
             />
-            <span>
-              # of Cases
-            </span>
-          </RadioLabel>
-          <RadioLabel>
+            # of Cases
+          </ModalRadioLabel>
+          <ModalRadioLabel>
             <RadioInput
               type="radio"
               name={`modalViewType-${activeTab}`}
@@ -55,10 +53,8 @@ export function HistogramPopupModalHistogramTab({
               checked={viewType[activeTab] === 'percentage'}
               onChange={(e) => setViewType((prev) => ({ ...prev, [activeTab]: e.target.value }))}
             />
-            <span>
-              % of Cases
-            </span>
-          </RadioLabel>
+            % of Cases
+          </ModalRadioLabel>
         </ModalRadioGroup>
       </ModalRadioFieldset>
       <ModalHistogramChartInset>
@@ -79,6 +75,7 @@ export function HistogramPopupModalHistogramTab({
               valueB={valueB}
               valueC={valueC}
               compact={requiresCompactSpacingModal(activeTab)}
+              expandedView
               height={modalHistogramDatasetChartHeight}
               width="100%"
               estimatedChartWidth={800}

--- a/src/pages/CohortAnalyzer/HistogramPanel/popup/HistogramPopupModalVennTab.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/popup/HistogramPopupModalVennTab.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ChartVenn from '../../vennDiagram/ChartVenn';
 import { HistogramChartEmptyState } from '../chart/HistogramChartEmptyState';
-import { ModalVennTabRoot } from '../HistogramPanel.styled';
+import { ModalPopupContentInset, ModalVennChartInset, ModalVennTabRoot } from '../HistogramPanel.styled';
 import VennCategoryRadios from '../../components/VennCategoryRadios';
 import { useCohortAnalyzer } from '../../context/CohortAnalyzerContext';
 
@@ -22,37 +22,42 @@ export function HistogramPopupModalVennTab({
   } = useCohortAnalyzer();
 
   return (
-    <ModalVennTabRoot ref={vennModalChartAreaRef}>
-      <VennCategoryRadios
-        selectedCohorts={selectedCohorts}
-        nodeIndex={nodeIndex}
-        setNodeIndex={setNodeIndex}
-        setRowData={setRowData}
-      />
-      {vennModalShowsChart ? (
-        <ChartVenn
-          {...chartVennModalProps}
-          containerRef={containerRef}
-          canvasRef={canvasRef}
-          slotWidth={vennModalSlot.slotWidth}
-          slotHeight={vennModalSlot.slotHeight}
-          expandedView
+    <ModalVennTabRoot>
+      <ModalPopupContentInset>
+        <VennCategoryRadios
+          selectedCohorts={selectedCohorts}
+          nodeIndex={nodeIndex}
+          setNodeIndex={setNodeIndex}
+          setRowData={setRowData}
+          alignWithModalHeader
         />
-      ) : vennModalShowsEmptyState ? (
-        <div
-          style={{
-            width: '100%',
-            flex: 1,
-            minHeight: Math.max(280, vennModalSlot.slotHeight - 40),
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            boxSizing: 'border-box',
-          }}
-        >
-          <HistogramChartEmptyState />
-        </div>
-      ) : null}
+      </ModalPopupContentInset>
+      <ModalVennChartInset ref={vennModalChartAreaRef}>
+        {vennModalShowsChart ? (
+          <ChartVenn
+            {...chartVennModalProps}
+            containerRef={containerRef}
+            canvasRef={canvasRef}
+            slotWidth={vennModalSlot.slotWidth}
+            slotHeight={vennModalSlot.slotHeight}
+            expandedView
+          />
+        ) : vennModalShowsEmptyState ? (
+          <div
+            style={{
+              width: '100%',
+              flex: 1,
+              minHeight: Math.max(280, vennModalSlot.slotHeight - 40),
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              boxSizing: 'border-box',
+            }}
+          >
+            <HistogramChartEmptyState />
+          </div>
+        ) : null}
+      </ModalVennChartInset>
     </ModalVennTabRoot>
   );
 }

--- a/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramBesideVennHistogramPortal.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramBesideVennHistogramPortal.js
@@ -82,7 +82,6 @@ export function HistogramBesideVennHistogramPortal({
 
   return createPortal(
     <ChartWrapper
-      id={`chart-beside-${d}`}
       data-ca-histogram-strip-dataset={d}
       ref={(el) => { chartRef.current[d] = el; }}
       style={{
@@ -222,6 +221,7 @@ export function HistogramBesideVennHistogramPortal({
       >
         {showChartBody ? (
           <div
+            id={`chart-beside-${d}`}
             className={classes.chartPlotArea}
             style={{
               minHeight: plotHeightPx,

--- a/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramStripChartRow.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramStripChartRow.js
@@ -187,7 +187,6 @@ export function HistogramStripChartRow({
         />
       )}
       <ChartWrapper
-        id={`chart-${dataset}`}
         data-ca-histogram-strip-dataset={dataset}
         ref={(el) => { chartRef.current[dataset] = el; }}
         style={{
@@ -393,6 +392,7 @@ export function HistogramStripChartRow({
                 </RadioGroup>
               </fieldset>
               <div
+                id={`chart-${dataset}`}
                 className={classes.chartPlotArea}
                 style={{ minHeight: plotH, height: plotH }}
               >

--- a/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelCore.styled.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelCore.styled.js
@@ -1,8 +1,9 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { CA_SURVIVAL_CARD_MIN_HEIGHT } from '../../store/cohortAnalyzerLayoutConstants';
 import {
   HISTOGRAM_CARD_MIN_WIDTH,
   HISTOGRAM_CARD_SHELL_MIN_VH,
+  HISTOGRAM_CHART_STROKE_COLOR,
 } from '../histogramConstants';
 
 export const barColors = {
@@ -17,6 +18,16 @@ export const kmplotColors = {
   colorC: '#008FF7',
 };
 
+/** Grid and axis strokes for Recharts-based charts (histogram + Kaplan–Meier). */
+export const histogramChartGridAxisStrokeCss = css`
+  & .recharts-cartesian-grid-horizontal line,
+  & .recharts-cartesian-grid-vertical line,
+  & .recharts-cartesian-axis .recharts-cartesian-axis-line,
+  & .recharts-cartesian-axis-tick line {
+    stroke: ${HISTOGRAM_CHART_STROKE_COLOR};
+  }
+`;
+
 export const HistogramContainer = styled.div`
   background: transparent;
   border: none;
@@ -30,6 +41,7 @@ export const HistogramContainer = styled.div`
   min-height: 0;
   height: auto;
   margin-top: 16px;
+  overflow-x: hidden;
   @media (max-width: 1900px) {
     max-width: 100%;
     margin: 16px 0 0;
@@ -117,6 +129,7 @@ export const ChartWrapper = styled.div`
   border-radius: 10px;
   box-shadow: none;
   transition: none;
+  ${histogramChartGridAxisStrokeCss}
   &:hover {
     transform: none;
     box-shadow: none;

--- a/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelModalSurvival.styled.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelModalSurvival.styled.js
@@ -1,6 +1,22 @@
-import styled from 'styled-components';
-import { HISTOGRAM_EXPANDED_AXIS_FONT_SIZE } from '../histogramConstants';
-import { RadioGroup, RadioLabel } from './histogramPanelCore.styled';
+import styled, { css } from 'styled-components';
+import {
+  HISTOGRAM_EXPANDED_AXIS_FONT_SIZE,
+  HISTOGRAM_EXPANDED_AXIS_FONT_FAMILY,
+  HISTOGRAM_EXPANDED_AXIS_FONT_WEIGHT,
+  HISTOGRAM_EXPANDED_AXIS_TICK_COLOR,
+} from '../histogramConstants';
+import { RadioGroup, RadioLabel, histogramChartGridAxisStrokeCss } from './histogramPanelCore.styled';
+
+/** Expanded modal ({@link HistogramPopup}) Recharts axis tick labels — X and Y. */
+const histogramExpandedModalAxisTickCss = css`
+  & .recharts-cartesian-axis-tick text,
+  & .recharts-cartesian-axis-tick-value {
+    font-size: ${HISTOGRAM_EXPANDED_AXIS_FONT_SIZE}px !important;
+    font-family: ${HISTOGRAM_EXPANDED_AXIS_FONT_FAMILY}, sans-serif !important;
+    font-weight: ${HISTOGRAM_EXPANDED_AXIS_FONT_WEIGHT} !important;
+    fill: ${HISTOGRAM_EXPANDED_AXIS_TICK_COLOR} !important;
+  }
+`;
 
 export const ModalOverlay = styled.div`
   position: fixed;
@@ -68,6 +84,8 @@ export const ModalChartWrapper = styled.div`
   min-height: 0;
   position: relative;
   z-index: 1;
+  ${histogramChartGridAxisStrokeCss}
+  ${histogramExpandedModalAxisTickCss}
 `;
 
 export const TabContainer = styled.div`
@@ -93,7 +111,7 @@ export const Tab = styled.button`
   padding: 10px 0px;
   cursor: pointer;
   font-family: Poppins;
-  font-size: 22px;
+  font-size: 16px;
   line-height: 1.25;
   white-space: nowrap;
   flex: 0 0 auto;
@@ -278,6 +296,7 @@ export const KmChartWrapper = styled.div`
   margin-top: -20px;
   overflow: hidden;
   box-sizing: border-box;
+  ${histogramChartGridAxisStrokeCss}
 `;
 
 export const RiskTableWrapper = styled.div`
@@ -301,7 +320,8 @@ export const KmChartWrapperBesideVenn = styled(KmChartWrapper)`
 export const RiskTableWrapperBesideVenn = styled(RiskTableWrapper)`
   padding-left: 8px;
   padding-right: 8px;
-  margin-top: 8px;
+  margin-top: -2px;
+  overflow: hidden;
 `;
 
 export const SurvivalAnalysisModalContainer = styled.div`
@@ -344,7 +364,12 @@ export const KmChartModalWrapper = styled.div`
   /* KaplanMeierChart axis ticks/labels are 11px in @bento-core/kmplot; match expanded modal spec. */
   & svg text {
     font-size: ${HISTOGRAM_EXPANDED_AXIS_FONT_SIZE}px !important;
+    font-family: ${HISTOGRAM_EXPANDED_AXIS_FONT_FAMILY}, sans-serif !important;
+    font-weight: ${HISTOGRAM_EXPANDED_AXIS_FONT_WEIGHT} !important;
+    fill: ${HISTOGRAM_EXPANDED_AXIS_TICK_COLOR} !important;
   }
+
+  ${histogramChartGridAxisStrokeCss}
 `;
 
 export const RiskTableModalWrapper = styled.div`

--- a/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelModalSurvival.styled.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelModalSurvival.styled.js
@@ -5,7 +5,19 @@ import {
   HISTOGRAM_EXPANDED_AXIS_FONT_WEIGHT,
   HISTOGRAM_EXPANDED_AXIS_TICK_COLOR,
 } from '../histogramConstants';
+import {
+  SURVIVAL_RISK_TABLE_DOWNLOAD_ATTR,
+  SURVIVAL_RISK_TABLE_DOWNLOAD_TEXT_COLOR,
+} from '../utils/survivalRiskTableDownloadCapture';
 import { RadioGroup, RadioLabel, histogramChartGridAxisStrokeCss } from './histogramPanelCore.styled';
+
+/** Risk table body text only — month header row (thead) keeps @bento-core/risk-table colors. */
+const survivalRiskTableDownloadTextCss = css`
+  &[${SURVIVAL_RISK_TABLE_DOWNLOAD_ATTR}='true'] tbody td,
+  &[${SURVIVAL_RISK_TABLE_DOWNLOAD_ATTR}='true'] tbody td * {
+    color: ${SURVIVAL_RISK_TABLE_DOWNLOAD_TEXT_COLOR} !important;
+  }
+`;
 
 /** Expanded modal ({@link HistogramPopup}) Recharts axis tick labels — X and Y. */
 const histogramExpandedModalAxisTickCss = css`
@@ -310,6 +322,7 @@ export const RiskTableWrapper = styled.div`
   min-height: 0;
   overflow: auto;
   box-sizing: border-box;
+  ${survivalRiskTableDownloadTextCss}
 `;
 
 export const KmChartWrapperBesideVenn = styled(KmChartWrapper)`
@@ -382,6 +395,7 @@ export const RiskTableModalWrapper = styled.div`
   align-items: center;
   height: 280px;
   padding-bottom: 15px;
+  ${survivalRiskTableDownloadTextCss}
 `;
 
 export const ModalHeaderContainer = styled.div`

--- a/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelModalSurvival.styled.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelModalSurvival.styled.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import { RadioGroup } from './histogramPanelCore.styled';
+import { HISTOGRAM_EXPANDED_AXIS_FONT_SIZE } from '../histogramConstants';
+import { RadioGroup, RadioLabel } from './histogramPanelCore.styled';
 
 export const ModalOverlay = styled.div`
   position: fixed;
@@ -31,6 +32,10 @@ export const ModalContent = styled.div`
 /** Shared hit target for chart-type, download, and close so flex gap reads evenly between items. */
 const MODAL_HEADER_ICON_CONTROL_PX = 38;
 
+/** Horizontal inset where header tab labels begin; popup content aligns to the same left edge. */
+export const MODAL_HEADER_TAB_INSET_PX = 44;
+export const MODAL_HEADER_TAB_INSET_RIGHT_PX = 44;
+
 export const CloseButton = styled.button`
   background: none;
   border: none;
@@ -54,24 +59,30 @@ export const CloseButton = styled.button`
 
 export const ModalChartWrapper = styled.div`
   width: 100%;
-  height: calc(100% - 56px);
+  height: calc(100% - 72.5px);
   margin-top: 0px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: stretch;
   min-height: 0;
+  position: relative;
+  z-index: 1;
 `;
 
 export const TabContainer = styled.div`
   display: flex;
   flex: 1;
   min-width: 0;
+  width: 100%;
   flex-wrap: nowrap;
   overflow-x: auto;
   overflow-y: hidden;
   align-items: stretch;
   gap: 30px;
+  padding-right: 4px;
+  position: relative;
+  z-index: 0;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
 `;
@@ -87,7 +98,7 @@ export const Tab = styled.button`
   white-space: nowrap;
   flex: 0 0 auto;
   font-weight: ${(props) => (props.active ? '600' : '400')};
-  color: ${(props) => (props.active ? '#3A7587' : '#666')};
+  color: ${(props) => (props.active ? '#3A7587' : '#4A5C5E')};
   border-bottom: ${(props) => (props.active ? '5px solid #3A7587' : 'none')};
 `;
 
@@ -102,6 +113,7 @@ export const ChartTypeDropdownRoot = styled.div`
   position: relative;
   display: inline-flex;
   align-items: center;
+  z-index: 2;
   margin-right: ${(p) => (p.$compactTrailingGap !== false ? '-8px' : '0')};
 `;
 
@@ -109,7 +121,7 @@ export const ChartTypeDropdownPanel = styled.div`
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  z-index: 1100;
+  z-index: 30;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -328,6 +340,11 @@ export const KmChartModalWrapper = styled.div`
   align-items: center;
   justify-content: center;
   overflow: visible;
+
+  /* KaplanMeierChart axis ticks/labels are 11px in @bento-core/kmplot; match expanded modal spec. */
+  & svg text {
+    font-size: ${HISTOGRAM_EXPANDED_AXIS_FONT_SIZE}px !important;
+  }
 `;
 
 export const RiskTableModalWrapper = styled.div`
@@ -343,16 +360,17 @@ export const RiskTableModalWrapper = styled.div`
 `;
 
 export const ModalHeaderContainer = styled.div`
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  column-gap: 12px;
   position: relative;
+  z-index: 2;
   width: 100%;
-  padding: 0 10px 0 4px;
+  padding: 16.5px ${MODAL_HEADER_TAB_INSET_RIGHT_PX}px 0 ${MODAL_HEADER_TAB_INSET_PX}px;
   box-sizing: border-box;
   min-height: 50px;
+  overflow: visible;
   border-bottom: 1px solid #969696;
   border-top-left-radius: 8px;
 `;
@@ -364,6 +382,10 @@ export const ModalActionButtons = styled.div`
   align-items: center;
   justify-content: flex-end;
   gap: 2px;
+  position: relative;
+  z-index: 3;
+  isolation: isolate;
+  pointer-events: auto;
 `;
 
 /** Stacks download control + dropdown anchor in one fixed-size cell so flex gap to close isn’t widened. */
@@ -433,33 +455,61 @@ export const ModalRadioFieldset = styled.fieldset`
   border: none;
   flex-shrink: 0;
   width: 100%;
-  padding: 0;
+  padding: 0 ${MODAL_HEADER_TAB_INSET_RIGHT_PX}px 0 ${MODAL_HEADER_TAB_INSET_PX}px;
   margin: 0;
+  box-sizing: border-box;
 `;
 
 export const ModalRadioGroup = styled(RadioGroup)`
   width: 100%;
-  margin: 20px 0 20px 60px;
+  margin: 20px 0;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
 `;
 
-/** Venn expanded tab: matches histogram chart / survival horizontal inset + max-width centering. */
+/** Expanded modal: # of Cases / % of Cases label typography. */
+export const ModalRadioLabel = styled(RadioLabel)`
+  font-family: Poppins, sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 16px;
+`;
+
+/** Wraps popup controls (e.g. Venn category radios) so they align with the first header tab. */
+export const ModalPopupContentInset = styled.div`
+  flex-shrink: 0;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 ${MODAL_HEADER_TAB_INSET_RIGHT_PX}px 0 ${MODAL_HEADER_TAB_INSET_PX}px;
+`;
+
+/** Venn expanded tab shell (full width); chart area uses {@link ModalVennChartInset}. */
 export const ModalVennTabRoot = styled.div`
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow: auto;
+  box-sizing: border-box;
+`;
+
+/** Venn diagram plot area — centered with chart inset; radios sit in {@link ModalPopupContentInset}. */
+export const ModalVennChartInset = styled.div`
   width: 100%;
   max-width: min(1100px, 100%);
   flex: 1;
   min-height: 0;
-  height: 100%;
   margin: 0 auto;
   padding: 0 clamp(20px, 4vw, 48px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  overflow: auto;
   box-sizing: border-box;
 `;
 

--- a/src/pages/CohortAnalyzer/HistogramPanel/survival/SurvivalAnalysisCardBody.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/survival/SurvivalAnalysisCardBody.js
@@ -226,6 +226,7 @@ export function SurvivalAnalysisCardBody({
                   onClick={() => downloadSurvivalCombined(
                     survivalAnalysisContainerRef,
                     () => setShowDownloadDropdown(false),
+                    riskTableRef,
                   )}
                 >
                   <img src={DownloadIconBorderless} alt="" style={{ width: '10px', height: '12px' }} />

--- a/src/pages/CohortAnalyzer/HistogramPanel/utils/histogramModalSurvivalDownloads.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/utils/histogramModalSurvivalDownloads.js
@@ -1,4 +1,5 @@
 import * as htmlToImage from 'html-to-image';
+import { beginSurvivalRiskTableDownloadCapture } from './survivalRiskTableDownloadCapture';
 
 /**
  * Survival tab downloads for ExpandedChartModal (KM SVG → PNG, risk table, combined).
@@ -6,6 +7,7 @@ import * as htmlToImage from 'html-to-image';
 export function createHistogramModalSurvivalDownloads({
   setShowDownloadDropdown,
   survivalAnalysisContainerRef,
+  riskTableRef,
 }) {
   const downloadKaplanMeierChart = (kmChartRef) => {
     try {
@@ -88,6 +90,7 @@ export function createHistogramModalSurvivalDownloads({
       const tableElement = riskTableRef.current;
       const originalHeight = tableElement.style.height;
       tableElement.style.height = 'auto';
+      const endDownloadCapture = beginSurvivalRiskTableDownloadCapture(tableElement);
       htmlToImage.toPng(tableElement, {
         backgroundColor: 'transparent',
         pixelRatio: 6,
@@ -106,6 +109,7 @@ export function createHistogramModalSurvivalDownloads({
         console.error('Error using html-to-image:', error);
         alert('Error downloading Risk table. Please check the console for details.');
       }).finally(() => {
+        endDownloadCapture();
         tableElement.style.height = originalHeight;
       });
       setShowDownloadDropdown(false);
@@ -126,6 +130,8 @@ export function createHistogramModalSurvivalDownloads({
       }
 
       const containerElement = survivalAnalysisContainerRef.current;
+      const riskTableElement = riskTableRef && riskTableRef.current ? riskTableRef.current : null;
+      const endDownloadCapture = beginSurvivalRiskTableDownloadCapture(riskTableElement);
 
       htmlToImage.toPng(containerElement, {
         backgroundColor: 'transparent',
@@ -145,6 +151,8 @@ export function createHistogramModalSurvivalDownloads({
       }).catch((error) => {
         console.error('Error downloading combined chart:', error);
         alert('Error downloading combined chart. Please check the console for details.');
+      }).finally(() => {
+        endDownloadCapture();
       });
     } catch (error) {
       console.error('Error downloading combined chart:', error);

--- a/src/pages/CohortAnalyzer/HistogramPanel/utils/histogramSurvivalDownloads.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/utils/histogramSurvivalDownloads.js
@@ -1,4 +1,5 @@
 import * as htmlToImage from 'html-to-image';
+import { beginSurvivalRiskTableDownloadCapture } from './survivalRiskTableDownloadCapture';
 
 /**
  * Capture Kaplan–Meier SVG as PNG download.
@@ -83,6 +84,8 @@ export function downloadRiskTable(riskTableRef) {
     tableElement.style.marginLeft = '0';
     tableElement.style.backgroundColor = 'transparent';
 
+    const endDownloadCapture = beginSurvivalRiskTableDownloadCapture(tableElement);
+
     htmlToImage.toPng(tableElement, {
       backgroundColor: 'transparent',
       pixelRatio: 4,
@@ -100,6 +103,7 @@ export function downloadRiskTable(riskTableRef) {
       console.error('Error using html-to-image:', error);
       alert('Error downloading Risk table. Please check the console for details.');
     }).finally(() => {
+      endDownloadCapture();
       tableElement.style.marginLeft = originalMargin;
       tableElement.style.backgroundColor = originalBackgroundColor;
     });
@@ -112,7 +116,7 @@ export function downloadRiskTable(riskTableRef) {
 /**
  * Combined survival section (KM + risk table) as one PNG.
  */
-export function downloadSurvivalCombined(survivalAnalysisContainerRef, onCloseDropdown) {
+export function downloadSurvivalCombined(survivalAnalysisContainerRef, onCloseDropdown, riskTableRef) {
   try {
     if (typeof onCloseDropdown === 'function') onCloseDropdown();
 
@@ -123,6 +127,8 @@ export function downloadSurvivalCombined(survivalAnalysisContainerRef, onCloseDr
     }
 
     const containerElement = survivalAnalysisContainerRef.current;
+    const riskTableElement = riskTableRef && riskTableRef.current ? riskTableRef.current : null;
+    const endDownloadCapture = beginSurvivalRiskTableDownloadCapture(riskTableElement);
 
     htmlToImage.toPng(containerElement, {
       backgroundColor: 'transparent',
@@ -142,6 +148,8 @@ export function downloadSurvivalCombined(survivalAnalysisContainerRef, onCloseDr
     }).catch((error) => {
       console.error('Error downloading combined chart:', error);
       alert('Error downloading combined chart. Please check the console for details.');
+    }).finally(() => {
+      endDownloadCapture();
     });
   } catch (error) {
     console.error('Error downloading combined chart:', error);

--- a/src/pages/CohortAnalyzer/HistogramPanel/utils/survivalRiskTableDownloadCapture.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/utils/survivalRiskTableDownloadCapture.js
@@ -1,0 +1,46 @@
+/** Applied to risk-table wrapper during html-to-image capture (strip + modal). */
+export const SURVIVAL_RISK_TABLE_DOWNLOAD_ATTR = 'data-survival-risk-table-download';
+
+export const SURVIVAL_RISK_TABLE_DOWNLOAD_TEXT_COLOR = '#000000';
+
+/**
+ * Forces cohort names and body cell values to render black in downloaded PNGs.
+ * Scoped to tbody only so thead month labels keep #3A7587 (see @bento-core/risk-table).
+ * @returns {() => void} call in finally to restore
+ */
+export function beginSurvivalRiskTableDownloadCapture(root) {
+  if (!root) return () => {};
+
+  root.setAttribute(SURVIVAL_RISK_TABLE_DOWNLOAD_ATTR, 'true');
+
+  const tbody = root.querySelector('tbody');
+  if (!tbody) {
+    return () => {
+      root.removeAttribute(SURVIVAL_RISK_TABLE_DOWNLOAD_ATTR);
+    };
+  }
+
+  const styledNodes = [];
+  const seen = new Set();
+  tbody.querySelectorAll('td, td *').forEach((node) => {
+    if (!(node instanceof HTMLElement) || seen.has(node)) return;
+    seen.add(node);
+    styledNodes.push({
+      node,
+      color: node.style.color,
+      priority: node.style.getPropertyPriority('color'),
+    });
+    node.style.setProperty('color', SURVIVAL_RISK_TABLE_DOWNLOAD_TEXT_COLOR, 'important');
+  });
+
+  return () => {
+    root.removeAttribute(SURVIVAL_RISK_TABLE_DOWNLOAD_ATTR);
+    styledNodes.forEach(({ node, color, priority }) => {
+      if (color) {
+        node.style.setProperty('color', color, priority);
+      } else {
+        node.style.removeProperty('color');
+      }
+    });
+  };
+}

--- a/src/pages/CohortAnalyzer/__tests__/test-entry-point/CohortAnalyzer.entryPoint.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/test-entry-point/CohortAnalyzer.entryPoint.test.js
@@ -433,6 +433,7 @@ describe('CohortAnalyzer page entry point', () => {
     expect(mockNotificationShow).toHaveBeenCalledWith(
       expect.stringContaining('Successfully created'),
       7000,
+      { width: '400px', textAlign: 'left' },
     );
   });
 

--- a/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
@@ -12,9 +12,9 @@ describe('cohortAnalyzerThemeConfig', () => {
     expect(cell.color).toBe('#0F253A');
   });
 
-  it('styles first-column body cells with purple links', () => {
+  it('styles first-column body cells with table link color', () => {
     const firstCol = cohortAnalyzerThemeConfig.tblBody.MuiTableCell.body['&:first-of-type'];
-    expect(firstCol.color).toBe('#763E96');
+    expect(firstCol.color).toBe('#004C73');
     expect(firstCol.fontWeight).toBe(600);
   });
 });

--- a/src/pages/CohortAnalyzer/components/VennCategoryRadios.js
+++ b/src/pages/CohortAnalyzer/components/VennCategoryRadios.js
@@ -87,12 +87,16 @@ const VennCategoryRadios = ({
   nodeIndex,
   setNodeIndex,
   setRowData,
+  alignWithModalHeader = false,
 }) => {
   const cohortsReady = Array.isArray(selectedCohorts) && selectedCohorts.length > 0;
   const rowOpacity = cohortsReady ? 1 : 0.55;
+  const resolvedContainerStyle = alignWithModalHeader
+    ? { ...containerStyle, padding: '12px 0 16px' }
+    : containerStyle;
 
   return (
-    <div style={containerStyle}>
+    <div style={resolvedContainerStyle}>
       <div style={promptRowStyle}>
         <p style={promptStyle}>Select a data category for cohort matching:</p>
         <ToolTip

--- a/src/pages/CohortAnalyzer/styling/cohortAnalyzerScrollbarStyles.js
+++ b/src/pages/CohortAnalyzer/styling/cohortAnalyzerScrollbarStyles.js
@@ -1,0 +1,10 @@
+/** Hide scrollbars while preserving scroll (Firefox, legacy Edge, WebKit). */
+export const cohortAnalyzerHiddenScrollbarStyles = {
+  scrollbarWidth: 'none',
+  msOverflowStyle: 'none',
+  '&::-webkit-scrollbar': {
+    display: 'none',
+    width: 0,
+    height: 0,
+  },
+};

--- a/src/pages/CohortAnalyzer/styling/cohortAnalyzerThemeConfig.js
+++ b/src/pages/CohortAnalyzer/styling/cohortAnalyzerThemeConfig.js
@@ -1,11 +1,12 @@
 import { themeConfig } from '../../studies/tableConfig/Theme';
 
 /**
- * Cohort Analyzer table typography tokens. Header + body share Primary 4; first-column links
- * use Purple 1. Sizes are spec'd as font-size / line-height / letter-spacing.
+ * Cohort Analyzer table typography tokens. Header + body share Primary 4; first-column
+ * (Participant ID) link styling uses TABLE_LINK_COLOR. Sizes are spec'd as font-size /
+ * line-height / letter-spacing.
  */
 const PRIMARY_4 = '#0F253A';
-const PURPLE_1 = '#763E96';
+const TABLE_LINK_COLOR = '#004C73';
 
 /**
  * Table + MUI overrides for Cohort Analyzer data grids (table view).
@@ -75,8 +76,8 @@ export const cohortAnalyzerThemeConfig = {
                 letterSpacing: '0',
                 color: PRIMARY_4,
                 '&:first-of-type': {
-                    // Table text links: Inter Semibold, 16/17/0, Purple 1.
-                    color: PURPLE_1,
+                    // Participant ID column: Inter Semibold, 16/17/0, TABLE_LINK_COLOR.
+                    color: TABLE_LINK_COLOR,
                     textDecoration: 'underline',
                     fontWeight: 600,
                 },

--- a/src/pages/CohortAnalyzer/styling/coreStyles.js
+++ b/src/pages/CohortAnalyzer/styling/coreStyles.js
@@ -14,6 +14,7 @@ export const cohortAnalyzerCoreStyles = (theme) => ({
     display: 'flex',
     flexDirection: 'row',
     flex: 1,
+    overflow: 'hidden',
   },
   chartContainer: {
     backgroundColor: 'white',
@@ -76,8 +77,7 @@ export const cohortAnalyzerCoreStyles = (theme) => ({
     minWidth: CA_VENN_OUTER_MIN_W,
     maxHeight: CA_VENN_OUTER_MAX_H,
     minHeight: CA_SURVIVAL_CARD_MIN_HEIGHT,
-    /* chartContainer also sets overflow hidden; allow long cohort labels that extend in layout padding. */
-    overflow: 'visible',
+    overflow: 'hidden',
     /** Fill card when resizing height; generic chartContainer uses 80% / 95% and hides growth. */
     '& .App': {
       width: '100%',
@@ -102,6 +102,7 @@ export const cohortAnalyzerCoreStyles = (theme) => ({
       alignItems: 'center',
       justifyContent: 'center',
       marginLeft: 0,
+      overflow: 'hidden',
     },
   },
   vennToolbarRow: {

--- a/src/pages/CohortAnalyzer/styling/layoutStyles.js
+++ b/src/pages/CohortAnalyzer/styling/layoutStyles.js
@@ -1,4 +1,6 @@
 /** Cohort sidebar, table shell, main analyzer column, and grid wrappers. */
+import { cohortAnalyzerHiddenScrollbarStyles } from './cohortAnalyzerScrollbarStyles';
+
 export const cohortAnalyzerLayoutStyles = (theme) => ({
   leftSideAnalyzer: {
     minWidth: 274,
@@ -184,14 +186,17 @@ export const cohortAnalyzerLayoutStyles = (theme) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'stretch',
-    overflowY: 'visible',
-    overflowX: 'visible',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    ...cohortAnalyzerHiddenScrollbarStyles,
     backgroundColor: 'rgba(255, 255, 255, 0.95)',
     backdropFilter: 'blur(10px)',
     boxShadow: '0 8px 32px rgba(0, 0, 0, 0.1)',
     [theme.breakpoints.down('lg')]: {
       alignItems: 'flex-start',
-      overflowY: 'scroll',
+      overflowX: 'hidden',
+      overflowY: 'auto',
+      ...cohortAnalyzerHiddenScrollbarStyles,
       padding: '0 0 0 0',
       height: '100%',
       minWidth: '0',
@@ -207,6 +212,7 @@ export const cohortAnalyzerLayoutStyles = (theme) => ({
   gridItemWrapper: {
     overflow: 'auto',
     minHeight: 0,
+    ...cohortAnalyzerHiddenScrollbarStyles,
     background: 'rgba(255, 255, 255, 0.95)',
     border: '1px solid #679AAA',
     borderRadius: 10,

--- a/src/pages/CohortAnalyzer/styling/summaryStyles.js
+++ b/src/pages/CohortAnalyzer/styling/summaryStyles.js
@@ -4,13 +4,16 @@ import {
   CA_TOP_ROW_GAP_PX,
   CA_VENN_OUTER_MIN_W,
 } from '../store/cohortAnalyzerLayoutConstants';
+import { cohortAnalyzerHiddenScrollbarStyles } from './cohortAnalyzerScrollbarStyles';
 
 /** Chart summary view: Venn row, tabs, controls, category cards, table area. */
 export const cohortAnalyzerSummaryStyles = (theme) => ({
   chartSummaryMain: {
     width: '100%',
+    minWidth: 0,
     marginBottom: 1,
     marginTop: '16px',
+    overflow: 'hidden',
   },
   chartSummaryHistogramFooter: {
     display: 'flex',
@@ -31,8 +34,8 @@ export const cohortAnalyzerSummaryStyles = (theme) => ({
     gap: CA_TOP_ROW_GAP_PX,
     width: '100%',
     minWidth: 0,
-    overflowX: 'visible',
-    overflowY: 'visible',
+    overflowX: 'hidden',
+    overflowY: 'hidden',
     position: 'relative',
     zIndex: 2,
     [theme.breakpoints.down('md')]: {
@@ -67,7 +70,7 @@ export const cohortAnalyzerSummaryStyles = (theme) => ({
     flexDirection: 'column',
     alignItems: 'stretch',
     alignSelf: 'stretch',
-    overflow: 'visible',
+    overflow: 'hidden',
     position: 'relative',
     [theme.breakpoints.down('md')]: {
       flex: '1 1 auto',
@@ -130,6 +133,9 @@ export const cohortAnalyzerSummaryStyles = (theme) => ({
     minWidth: 0,
     paddingTop: 14,
     boxSizing: 'border-box',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    ...cohortAnalyzerHiddenScrollbarStyles,
   },
   /** Row: chart/table tabs on the left, optional actions (e.g. README) on the far right. */
   summaryTabsBar: {
@@ -200,6 +206,9 @@ export const cohortAnalyzerSummaryStyles = (theme) => ({
     marginTop: 0,
     display: 'flex',
     flexDirection: 'column',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    ...cohortAnalyzerHiddenScrollbarStyles,
   },
   chartTopControlRow: {
     alignSelf: 'stretch',
@@ -446,17 +455,8 @@ export const cohortAnalyzerSummaryStyles = (theme) => ({
   rightSideTableContainer: {
     width: '100%',
     maxHeight: 540,
-    overflowY: 'scroll',
-    '&::-webkit-scrollbar': {
-      width: '6px',
-    },
-    '&::-webkit-scrollbar-thumb': {
-      width: '6px',
-      backgroundColor: '#003F74',
-    },
-    '&::-webkit-scrollbar-track': {
-      background: '#CECECE',
-    },
+    overflowY: 'auto',
+    ...cohortAnalyzerHiddenScrollbarStyles,
     [theme.breakpoints.down('lg')]: {
       width: '100%',
     },

--- a/src/pages/CohortAnalyzer/vennDiagram/ChartVenn.js
+++ b/src/pages/CohortAnalyzer/vennDiagram/ChartVenn.js
@@ -349,10 +349,10 @@ useEffect(() => {
           width: '100%',
           display: 'flex',
           alignItems: 'center',
-          minHeight: '100%',
+          minHeight: 0,
           justifyContent: 'center',
           padding: 0,
-          overflow: 'visible',
+          overflow: 'hidden',
         }}
       >
         <canvas ref={canvasRef} id="canvas" />

--- a/src/pages/CohortAnalyzer/vennDiagram/VennDiagramContainer.js
+++ b/src/pages/CohortAnalyzer/vennDiagram/VennDiagramContainer.js
@@ -224,7 +224,7 @@ const VennDiagramContainer = ({
         onExpandVenn={onExpandVenn}
         classes={classes}
       />
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, minHeight: 0, width: '100%' }}>
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, minHeight: 0, width: '100%', overflow: 'hidden' }}>
         {showChartVenn && (
           <ChartVenn
             {...chartVennProps}


### PR DESCRIPTION
### Overview
Design QA round 3 for the Cohort Analyzer: layout and typography aligned to spec, chart/survival download behavior fixed, and scrollbar/overflow polish on the main analyzer shell. Includes table action bar spacing in CohortAnalyzerTableSection and histogram/survival/Venn updates across the chart summary area.

### Change Details (Specifics)
Cohort Analyzer shell & table view
CohortAnalyzerTableSection: Action bar button spacing set to 26px gap (Create Cohort, Download, Build in Explore).
Table theme (cohortAnalyzerThemeConfig): Center-aligned headers/cells; Participant ID link color #004C73 (Inter Semibold 16px).
Scrollbars: Hidden on main analyzer column and chart summary panels (Firefox / WebKit / legacy Edge) while scroll still works.
Overflow: Chart summary and Venn areas clip overflow instead of showing nested scrollbars where not intended.
Cohort Selector (design comments 332–335)
Panel width 274px, height 400px, title 32px top padding.
Full-width #F1F1F1 sort bar via padding (no side margin gap).
Histogram panel — expanded modal & charts
Modal header: 44px left/right inset, 16.5px top padding; grid layout so tabs do not overlap chart-type / download / close controls.
Expanded modal axis labels: 13px Nunito, weight 500, color #666666 (histogram + KM).
Chart strokes unified to #CCCCCC (grid, axes, bar/pie outlines).
Venn strip card: overflow: hidden on plot area (clip vs scroll on Y).
Histogram & survival downloads
Histogram download: Targets Recharts plot SVG (svg.recharts-surface), not chart-type icon SVG; plot id moved to chart area only; supports beside-Venn cards (chart-beside-*).
Survival risk table download: Body cells and cohort names render black (#000000) in PNGs; thead month headers unchanged (#3A7587 per @bento-core/risk-table).
Applies to Risk Table only, Download Both, and expanded modal survival downloads via survivalRiskTableDownloadCapture.js.
Demo cohort notification
Success toast: 400px width, left-aligned text/icon, line break between sentences.
Related Ticket(s)
C3DC-2171 — Cohort Analyzer design QA (layout, table alignment, sidebar, histogram modal)
Design QA R3 — Branch Design-qa-R3 (follow-up QA + download fixes)
Test plan

 Chart Summary: Venn + survival top row; resize Venn — no stray scrollbars on analyzer column

 Histogram strip: download exports chart (not chart-type icon); expanded modal axes 13px / #666666

 Survival: Risk Table + Download Both — black body/cohort text, teal month headers unchanged

 Table View: centered columns; Participant ID #004C73; action buttons 26px apart

 Cohort Selector: 274×400 panel, 32px title offset, full-width sort bar

 Load demo cohorts — notification layout and copy
