### PR TITLE
Design QA Final comments

### DIFF
--- a/src/bento/cohortAnalyzerPageData.js
+++ b/src/bento/cohortAnalyzerPageData.js
@@ -34,7 +34,7 @@ export const tableConfig = {
     },
     {
       dataField: 'dbgap_accession',
-      header: 'dbGaP Accession',
+      header: 'Study ID',
       display: true,
       tooltipText: 'sort',
       role: cellTypes.DISPLAY,

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/CustomCategoryAxisTick.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/CustomCategoryAxisTick.js
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
+import CustomChartTooltip from './CustomChartTooltip';
+
+const formatCategoryLabel = (raw) => {
+  if (raw === 'OtherFew') return 'Other Few';
+  if (raw === 'OtherMany') return 'Other Many';
+  return raw;
+};
+
+const getCharWidth = (fontSize) => {
+  if (fontSize <= 8) return 4;
+  if (fontSize <= 11) return 5;
+  return Math.ceil(fontSize * 0.55);
+};
+
+/**
+ * Word-wrap category labels within maxWidth; truncate the last line with "..." when needed.
+ */
+const wrapCategoryLabel = (text, maxWidth, fontSize, maxLines) => {
+  const maxChars = Math.max(4, Math.floor(maxWidth / getCharWidth(fontSize)));
+
+  if (text.length <= maxChars) {
+    return { lines: [text], isTruncated: false };
+  }
+
+  const words = text.split(/\s+/).filter(Boolean);
+  const lines = [];
+  let current = '';
+
+  const pushCurrent = () => {
+    if (current) {
+      lines.push(current);
+      current = '';
+    }
+  };
+
+  words.forEach((word) => {
+    if (lines.length >= maxLines) {
+      return;
+    }
+
+    const candidate = current ? `${current} ${word}` : word;
+
+    if (candidate.length <= maxChars) {
+      current = candidate;
+      return;
+    }
+
+    if (current) {
+      pushCurrent();
+    }
+
+    if (word.length > maxChars) {
+      lines.push(`${word.substring(0, maxChars - 3)}...`);
+      current = '';
+      return;
+    }
+
+    current = word;
+  });
+
+  if (lines.length < maxLines && current) {
+    lines.push(current);
+  } else if (current && lines.length >= maxLines) {
+    const lastIndex = maxLines - 1;
+    const lastLine = lines[lastIndex] || '';
+    const merged = lastLine ? `${lastLine} ${current}` : current;
+    if (merged.length <= maxChars) {
+      lines[lastIndex] = merged;
+    } else {
+      lines[lastIndex] = `${merged.substring(0, maxChars - 3)}...`;
+    }
+  }
+
+  const resultLines = lines.slice(0, maxLines);
+  if (resultLines.length === 0) {
+    return {
+      lines: [`${text.substring(0, maxChars - 3)}...`],
+      isTruncated: true,
+    };
+  }
+
+  const lastLine = resultLines[resultLines.length - 1] || '';
+  const isTruncated = lastLine.indexOf('...') >= 0
+    || resultLines.join(' ').replace(/\s+/g, ' ').trim().length < text.length;
+
+  return { lines: resultLines, isTruncated };
+};
+
+/**
+ * Y-axis category labels for horizontal bar charts — word-wrap, truncate, vertically centered on each bar row.
+ */
+const CustomCategoryAxisTick = ({
+  x,
+  y,
+  payload,
+  width = 100,
+  fontSize = 10,
+  lineHeight = fontSize,
+  letterSpacing = 0,
+  fill = '#666666',
+  fontFamily = 'Nunito',
+  fontWeight = 500,
+  maxLines = 2,
+}) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+
+  const payloadValue = payload && payload.value != null ? payload.value : '';
+  const fullText = formatCategoryLabel(payloadValue);
+  const { lines, isTruncated } = wrapCategoryLabel(fullText, width, fontSize, maxLines);
+
+  const lineGap = 2;
+  const blockHeight = lines.length * lineHeight + (lines.length - 1) * lineGap;
+  const firstLineY = -(blockHeight / 2) + (lineHeight / 2);
+
+  const handleMouseEnter = (e) => {
+    if (!isTruncated) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    setMousePos({
+      x: rect.left + rect.width / 2,
+      y: rect.top - 8,
+    });
+    setShowTooltip(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowTooltip(false);
+  };
+
+  return (
+    <>
+      <g transform={`translate(${x},${y})`}>
+        <title>{fullText}</title>
+        {isTruncated && (
+          <rect
+            x={-width}
+            y={-(blockHeight / 2) - 2}
+            width={width}
+            height={blockHeight + 4}
+            fill="transparent"
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          />
+        )}
+        {lines.map((line, index) => (
+          <text
+            key={index}
+            x={-6}
+            y={firstLineY + index * (lineHeight + lineGap)}
+            dy={4}
+            textAnchor="end"
+            fill={fill}
+            fontSize={fontSize}
+            fontFamily={fontFamily}
+            fontWeight={fontWeight}
+            style={{
+              letterSpacing: `${letterSpacing}px`,
+              lineHeight: `${lineHeight}px`,
+              pointerEvents: isTruncated ? 'none' : 'auto',
+            }}
+          >
+            <title>{fullText}</title>
+            {line}
+          </text>
+        ))}
+      </g>
+      {showTooltip && isTruncated && ReactDOM.createPortal(
+        <div
+          style={{
+            position: 'fixed',
+            left: mousePos.x,
+            top: mousePos.y,
+            transform: 'translate(-50%, -100%)',
+            pointerEvents: 'none',
+            zIndex: 9999,
+          }}
+        >
+          <CustomChartTooltip active label={fullText} showValue={false} />
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+};
+
+export default CustomCategoryAxisTick;

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
@@ -367,6 +367,8 @@ export function HistogramDatasetChart({
             dataKey="name"
             type="category"
             width={categoryAxisWidth}
+            interval={0}
+            minTickGap={0}
             axisLine={chartAxisLine}
             tickLine={chartTickLine}
             tick={(props) => (

--- a/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/chart/HistogramDatasetChart.js
@@ -15,7 +15,14 @@ import {
 } from 'recharts';
 import CustomChartTooltip from './CustomChartTooltip';
 import CustomXAxisTick from './CustomXAxisTick';
-import { HISTOGRAM_CHART_STROKE_COLOR, HISTOGRAM_EXPANDED_AXIS_TICK_PROPS } from '../histogramConstants';
+import CustomCategoryAxisTick from './CustomCategoryAxisTick';
+import {
+  BESIDE_HORIZONTAL_BAR_BAR_GAP,
+  BESIDE_HORIZONTAL_BAR_CATEGORY_GAP,
+  HISTOGRAM_CHART_STROKE_COLOR,
+  HISTOGRAM_EXPANDED_AXIS_TICK_PROPS,
+  HORIZONTAL_BAR_MAX_CATEGORY_LABEL_LINES,
+} from '../histogramConstants';
 import { barColors } from '../HistogramPanel.styled';
 
 export const CHART_TYPE_KEYS = {
@@ -136,6 +143,8 @@ export function HistogramDatasetChart({
   c3Name = 'Cohort C',
   previewShell = false,
   expandedView = false,
+  /** Wider gaps between horizontal-bar categories (beside-Venn column). */
+  relaxedHorizontalBarSpacing = false,
 }) {
   const yAxisTickStyle = buildYAxisTickStyle(expandedView);
   const xTickProps = buildXTickProps(expandedView, compact);
@@ -168,12 +177,33 @@ export function HistogramDatasetChart({
 
   const lineMargin = { ...verticalBarMargin };
 
-  const horizontalBarMargin = {
-    top: 12,
-    right: 24,
-    left: compact ? 18 : 18,
-    bottom: 12,
-  };
+  const categoryAxisWidth = relaxedHorizontalBarSpacing
+    ? (compact ? 96 : 116)
+    : expandedView
+      ? 140
+      : (compact ? 92 : 112);
+
+  const horizontalBarCategoryGap = relaxedHorizontalBarSpacing
+    ? BESIDE_HORIZONTAL_BAR_CATEGORY_GAP
+    : dataLength >= 6
+      ? '32%'
+      : dataLength >= 4
+        ? '26%'
+        : '20%';
+
+  const horizontalBarMargin = relaxedHorizontalBarSpacing
+    ? {
+      top: 16,
+      right: 24,
+      left: 8,
+      bottom: 16,
+    }
+    : {
+      top: 12,
+      right: 24,
+      left: expandedView ? 12 : 8,
+      bottom: 12,
+    };
 
   const pieMargin = { top: 8, right: 8, left: 8, bottom: 8 };
 
@@ -317,7 +347,13 @@ export function HistogramDatasetChart({
   if (chartType === CHART_TYPE_KEYS.HORIZONTAL_BAR) {
     return (
       <ResponsiveContainer width={width} height={height}>
-        <BarChart layout="vertical" data={rows} margin={horizontalBarMargin}>
+        <BarChart
+          layout="vertical"
+          data={rows}
+          margin={horizontalBarMargin}
+          barCategoryGap={horizontalBarCategoryGap}
+          barGap={relaxedHorizontalBarSpacing ? BESIDE_HORIZONTAL_BAR_BAR_GAP : 4}
+        >
           <CartesianGrid strokeDasharray="3 3" stroke={HISTOGRAM_CHART_STROKE_COLOR} horizontal vertical={false} />
           <XAxis
             type="number"
@@ -330,15 +366,27 @@ export function HistogramDatasetChart({
           <YAxis
             dataKey="name"
             type="category"
-            width={compact ? 90 : 110}
-            tick={categoryAxisTickStyle}
-            tickFormatter={(v) => formatCategoryLabel(v)}
+            width={categoryAxisWidth}
             axisLine={chartAxisLine}
             tickLine={chartTickLine}
+            tick={(props) => (
+              <CustomCategoryAxisTick
+                {...props}
+                width={categoryAxisWidth - 8}
+                maxLines={HORIZONTAL_BAR_MAX_CATEGORY_LABEL_LINES}
+                {...categoryAxisTickStyle}
+              />
+            )}
           />
           <Tooltip content={<MultiseriesTooltip viewType={viewType} />} />
           {valueA > 0 && (
-            <Bar dataKey="valueA" name="Cohort A" maxBarSize={28} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
+            <Bar
+              dataKey="valueA"
+              name="Cohort A"
+              maxBarSize={relaxedHorizontalBarSpacing ? 22 : 28}
+              stroke={HISTOGRAM_CHART_STROKE_COLOR}
+              strokeWidth={0.6}
+            >
               {rows.map((entry, entryIndex) => (
                 <Cell
                   key={`hbar-a-${entryIndex}`}
@@ -350,7 +398,13 @@ export function HistogramDatasetChart({
             </Bar>
           )}
           {valueB > 0 && (
-            <Bar dataKey="valueB" name="Cohort B" maxBarSize={28} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
+            <Bar
+              dataKey="valueB"
+              name="Cohort B"
+              maxBarSize={relaxedHorizontalBarSpacing ? 22 : 28}
+              stroke={HISTOGRAM_CHART_STROKE_COLOR}
+              strokeWidth={0.6}
+            >
               {rows.map((entry, entryIndex) => (
                 <Cell
                   key={`hbar-b-${entryIndex}`}
@@ -362,7 +416,13 @@ export function HistogramDatasetChart({
             </Bar>
           )}
           {valueC > 0 && (
-            <Bar dataKey="valueC" name="Cohort C" maxBarSize={28} stroke={HISTOGRAM_CHART_STROKE_COLOR} strokeWidth={0.6}>
+            <Bar
+              dataKey="valueC"
+              name="Cohort C"
+              maxBarSize={relaxedHorizontalBarSpacing ? 22 : 28}
+              stroke={HISTOGRAM_CHART_STROKE_COLOR}
+              strokeWidth={0.6}
+            >
               {rows.map((entry, entryIndex) => (
                 <Cell
                   key={`hbar-c-${entryIndex}`}

--- a/src/pages/CohortAnalyzer/HistogramPanel/histogramConstants.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/histogramConstants.js
@@ -43,3 +43,10 @@ export const HISTOGRAM_EXPANDED_AXIS_TICK_PROPS = {
 
 /** Grid, axis, and shape outline color for histogram and survival charts in this panel. */
 export const HISTOGRAM_CHART_STROKE_COLOR = '#CCCCCC';
+
+/** Max wrapped lines for horizontal-bar category labels (Y axis). */
+export const HORIZONTAL_BAR_MAX_CATEGORY_LABEL_LINES = 2;
+
+/** Horizontal bar spacing in the narrow beside-Venn column to keep category labels from overlapping. */
+export const BESIDE_HORIZONTAL_BAR_CATEGORY_GAP = '42%';
+export const BESIDE_HORIZONTAL_BAR_BAR_GAP = 6;

--- a/src/pages/CohortAnalyzer/HistogramPanel/popup/HistogramPopupModalHistogramTab.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/popup/HistogramPopupModalHistogramTab.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import {
-  RadioInput,
+  CohortAnalyzerRadioInput,
+} from '../../styling/cohortAnalyzerRadio.styled';
+import {
   ModalChartContainer,
   ModalHistogramChartInset,
   ModalRadioFieldset,
-  ModalRadioGroup,
   ModalRadioLabel,
   ModalNoDataContainer,
 } from '../HistogramPanel.styled';
@@ -34,28 +35,24 @@ export function HistogramPopupModalHistogramTab({
   return (
     <ModalChartContainer>
       <ModalRadioFieldset>
-        <ModalRadioGroup>
-          <ModalRadioLabel>
-            <RadioInput
-              type="radio"
-              name={`modalViewType-${activeTab}`}
-              value="count"
-              checked={viewType[activeTab] === 'count'}
-              onChange={(e) => setViewType((prev) => ({ ...prev, [activeTab]: e.target.value }))}
-            />
-            # of Cases
-          </ModalRadioLabel>
-          <ModalRadioLabel>
-            <RadioInput
-              type="radio"
-              name={`modalViewType-${activeTab}`}
-              value="percentage"
-              checked={viewType[activeTab] === 'percentage'}
-              onChange={(e) => setViewType((prev) => ({ ...prev, [activeTab]: e.target.value }))}
-            />
-            % of Cases
-          </ModalRadioLabel>
-        </ModalRadioGroup>
+        <ModalRadioLabel>
+          <CohortAnalyzerRadioInput
+            name={`modalViewType-${activeTab}`}
+            value="count"
+            checked={viewType[activeTab] === 'count'}
+            onChange={(e) => setViewType((prev) => ({ ...prev, [activeTab]: e.target.value }))}
+          />
+          # of Cases
+        </ModalRadioLabel>
+        <ModalRadioLabel>
+          <CohortAnalyzerRadioInput
+            name={`modalViewType-${activeTab}`}
+            value="percentage"
+            checked={viewType[activeTab] === 'percentage'}
+            onChange={(e) => setViewType((prev) => ({ ...prev, [activeTab]: e.target.value }))}
+          />
+          % of Cases
+        </ModalRadioLabel>
       </ModalRadioFieldset>
       <ModalHistogramChartInset>
         {Array.isArray(data[activeTab]) && data[activeTab].length > 0 ? (

--- a/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramBesideVennHistogramPortal.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/strip/HistogramBesideVennHistogramPortal.js
@@ -253,6 +253,7 @@ export function HistogramBesideVennHistogramPortal({
               c2Name={c2Name || 'Cohort B'}
               c3Name={c3Name || 'Cohort C'}
               previewShell={chartPreviewMode}
+              relaxedHorizontalBarSpacing
             />
           </div>
         ) : (

--- a/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelModalSurvival.styled.js
+++ b/src/pages/CohortAnalyzer/HistogramPanel/styles/histogramPanelModalSurvival.styled.js
@@ -10,6 +10,10 @@ import {
   SURVIVAL_RISK_TABLE_DOWNLOAD_TEXT_COLOR,
 } from '../utils/survivalRiskTableDownloadCapture';
 import { RadioGroup, RadioLabel, histogramChartGridAxisStrokeCss } from './histogramPanelCore.styled';
+import {
+  CohortAnalyzerRadioFieldset,
+  CohortAnalyzerRadioLabel,
+} from '../../styling/cohortAnalyzerRadio.styled';
 
 /** Risk table body text only — month header row (thead) keeps @bento-core/risk-table colors. */
 const survivalRiskTableDownloadTextCss = css`
@@ -490,31 +494,26 @@ export const ModalHistogramChartInset = styled.div`
   box-sizing: border-box;
 `;
 
-export const ModalRadioFieldset = styled.fieldset`
+export const ModalRadioFieldset = styled(CohortAnalyzerRadioFieldset)`
   border: none;
   flex-shrink: 0;
   width: 100%;
   padding: 0 ${MODAL_HEADER_TAB_INSET_RIGHT_PX}px 0 ${MODAL_HEADER_TAB_INSET_PX}px;
-  margin: 0;
-  box-sizing: border-box;
-`;
-
-export const ModalRadioGroup = styled(RadioGroup)`
-  width: 100%;
   margin: 20px 0;
-  display: flex;
-  flex-direction: row;
+  box-sizing: border-box;
   flex-wrap: wrap;
   align-items: center;
 `;
 
-/** Expanded modal: # of Cases / % of Cases label typography. */
-export const ModalRadioLabel = styled(RadioLabel)`
-  font-family: Poppins, sans-serif;
-  font-weight: 400;
-  font-style: normal;
-  font-size: 16px;
+export const ModalRadioGroup = styled(RadioGroup)`
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  display: contents;
 `;
+
+/** Expanded modal: # of Cases / % of Cases — matches Venn category radio typography. */
+export const ModalRadioLabel = styled(CohortAnalyzerRadioLabel)``;
 
 /** Wraps popup controls (e.g. Venn category radios) so they align with the first header tab. */
 export const ModalPopupContentInset = styled.div`

--- a/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
@@ -12,9 +12,10 @@ describe('cohortAnalyzerThemeConfig', () => {
     expect(cell.color).toBe('#0F253A');
   });
 
-  it('styles first-column body cells with table link color', () => {
+  it('styles first-column body cells the same as other columns', () => {
     const firstCol = cohortAnalyzerThemeConfig.tblBody.MuiTableCell.body['&:first-of-type'];
-    expect(firstCol.color).toBe('#004C73');
-    expect(firstCol.fontWeight).toBe(600);
+    expect(firstCol.color).toBe('#0F253A');
+    expect(firstCol.fontWeight).toBe(400);
+    expect(firstCol.textDecoration).toBe('none');
   });
 });

--- a/src/pages/CohortAnalyzer/components/VennCategoryRadios.js
+++ b/src/pages/CohortAnalyzer/components/VennCategoryRadios.js
@@ -1,24 +1,11 @@
 import React from 'react';
 import ToolTip from '@bento-core/tool-tip/dist/ToolTip';
 import questionIcon3 from '../../../assets/icons/Question_icon_2.svg';
-
-const vennRadioStyle = (selected) => ({
-  appearance: 'none',
-  WebkitAppearance: 'none',
-  width: 16,
-  height: 16,
-  margin: 0,
-  marginRight: 6,
-  cursor: 'pointer',
-  borderRadius: '50%',
-  border: '2px solid #5C5C5C',
-  backgroundColor: '#FFFFFF',
-  backgroundImage: selected
-    ? 'radial-gradient(circle, #3A7587 0 4px, transparent 4.5px)'
-    : 'none',
-  flexShrink: 0,
-  boxSizing: 'border-box',
-});
+import {
+  CohortAnalyzerRadioFieldset,
+  CohortAnalyzerRadioInput,
+  CohortAnalyzerRadioLabel,
+} from '../styling/cohortAnalyzerRadio.styled';
 
 const containerStyle = {
   padding: '12px 16px 16px',
@@ -41,20 +28,6 @@ const promptStyle = {
   fontFamily: 'Poppins',
   color: '#5C5C5C',
   lineHeight: 1.35,
-};
-
-const radioContainerStyle = {
-  display: 'flex',
-  flexDirection: 'row',
-  flexWrap: 'nowrap',
-  marginTop: 10,
-  gap: 16,
-  padding: 0,
-  margin: '10px 0 0',
-  color: '#1C2B33',
-  fontSize: 16,
-  fontFamily: 'Poppins, sans-serif',
-  border: 'none',
 };
 
 const legendOffscreenStyle = {
@@ -109,7 +82,7 @@ const VennCategoryRadios = ({
           <img alt="Help" src={questionIcon3} style={{ display: 'block' }} height={12} />
         </ToolTip>
       </div>
-      <fieldset style={radioContainerStyle}>
+      <CohortAnalyzerRadioFieldset>
         <legend style={legendOffscreenStyle}>Data category options</legend>
         {RADIO_OPTIONS.map(({ value, label }) => (
           <ToolTip
@@ -120,19 +93,14 @@ const VennCategoryRadios = ({
             arrow
             placement="top"
           >
-            <label
+            <CohortAnalyzerRadioLabel
               style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                margin: 0,
                 opacity: rowOpacity,
                 cursor: cohortsReady ? 'pointer' : 'not-allowed',
               }}
             >
-              <input
-                style={vennRadioStyle(nodeIndex === value)}
+              <CohortAnalyzerRadioInput
                 disabled={!cohortsReady}
-                type="radio"
                 value={String(value + 1)}
                 checked={nodeIndex === value}
                 onChange={() => {
@@ -143,10 +111,10 @@ const VennCategoryRadios = ({
                 aria-label={label}
               />
               {label}
-            </label>
+            </CohortAnalyzerRadioLabel>
           </ToolTip>
         ))}
-      </fieldset>
+      </CohortAnalyzerRadioFieldset>
     </div>
   );
 };

--- a/src/pages/CohortAnalyzer/styling/cohortAnalyzerRadio.styled.js
+++ b/src/pages/CohortAnalyzer/styling/cohortAnalyzerRadio.styled.js
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+/** Shared radio appearance for Venn category controls and histogram expanded modal. */
+export const CohortAnalyzerRadioInput = styled.input.attrs({ type: 'radio' })`
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  margin-right: 6px;
+  cursor: pointer;
+  border-radius: 50%;
+  border: 2px solid #5C5C5C;
+  background-color: #FFFFFF;
+  flex-shrink: 0;
+  box-sizing: border-box;
+
+  &:checked {
+    background-image: radial-gradient(circle, #3A7587 0 4px, transparent 4.5px);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+export const CohortAnalyzerRadioLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  font-family: Poppins, sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  color: #1C2B33;
+  cursor: pointer;
+`;
+
+export const CohortAnalyzerRadioFieldset = styled.fieldset`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: 16px;
+  padding: 0;
+  margin: 10px 0 0;
+  color: #1C2B33;
+  font-size: 16px;
+  font-family: Poppins, sans-serif;
+  border: none;
+`;

--- a/src/pages/CohortAnalyzer/styling/cohortAnalyzerThemeConfig.js
+++ b/src/pages/CohortAnalyzer/styling/cohortAnalyzerThemeConfig.js
@@ -1,12 +1,10 @@
 import { themeConfig } from '../../studies/tableConfig/Theme';
 
 /**
- * Cohort Analyzer table typography tokens. Header + body share Primary 4; first-column
- * (Participant ID) link styling uses TABLE_LINK_COLOR. Sizes are spec'd as font-size /
- * line-height / letter-spacing.
+ * Cohort Analyzer table typography tokens. Header + body share Primary 4.
+ * Sizes are spec'd as font-size / line-height / letter-spacing.
  */
 const PRIMARY_4 = '#0F253A';
-const TABLE_LINK_COLOR = '#004C73';
 
 /**
  * Table + MUI overrides for Cohort Analyzer data grids (table view).
@@ -22,7 +20,7 @@ export const cohortAnalyzerThemeConfig = {
                 borderBottom: '1px solid #000000',
             },
         },
-        // Center all column headers; first column keeps link styling in body rows only.
+        // Center all column headers.
         MuiTableCell: {
             ...(themeConfig.tblHeader && themeConfig.tblHeader.MuiTableCell),
             root: {
@@ -75,11 +73,11 @@ export const cohortAnalyzerThemeConfig = {
                 lineHeight: '17px',
                 letterSpacing: '0',
                 color: PRIMARY_4,
+                // Override studies table first-column link color; all columns use body text styling.
                 '&:first-of-type': {
-                    // Participant ID column: Inter Semibold, 16/17/0, TABLE_LINK_COLOR.
-                    color: TABLE_LINK_COLOR,
-                    textDecoration: 'underline',
-                    fontWeight: 600,
+                    color: PRIMARY_4,
+                    textDecoration: 'none',
+                    fontWeight: 400,
                 },
             },
         },


### PR DESCRIPTION
### Summary
Design QA polish for the Cohort Analyzer participant table and histogram expanded view: table column/header updates, rotated (horizontal) bar chart label fixes, and consistent radio button styling across the histogram popup and Venn diagram.

### Changes
Participant table
Renamed dbGaP Accession column header to Study ID in cohortAnalyzerPageData.js
Removed special link styling from the Participant ID column — all table body cells now use the same Primary 4 text styling (cohortAnalyzerThemeConfig.js)
Horizontal (rotated) bar chart labels
Added CustomCategoryAxisTick for Y-axis category labels: word-wrap (up to 2 lines), truncation with ..., tooltip on overflow, and vertical centering on each bar row
Tuned HistogramDatasetChart horizontal bar layout: dynamic category spacing, beside-Venn relaxed spacing, and custom Y-axis ticks instead of default Recharts labels
Fixed overlapping/skipped labels by forcing interval={0} and minTickGap={0} so every category label renders
Reduced excess space between labels and bars in the plot area
Histogram popup radio consistency
Introduced shared cohortAnalyzerRadio.styled.js (CohortAnalyzerRadioInput, CohortAnalyzerRadioLabel, CohortAnalyzerRadioFieldset)
Updated Venn category radios and expanded modal # of Cases / % of Cases radios to use the same design
Aligned modal histogram chart inset with header/radio layout in histogramPanelModalSurvival.styled.js
Test plan

