### PR TITLE
* fixed table font weight

### DIFF
--- a/src/pages/CohortAnalyzer/CohortAnalyzer.js
+++ b/src/pages/CohortAnalyzer/CohortAnalyzer.js
@@ -41,6 +41,7 @@ import {
     canAddExampleCohorts,
     buildExploreUploadPayload,
     shouldSkipNavigateAwayModal,
+    guardSetterForRequest,
 } from './cohortAnalyzerPageLogic';
 
 export const CohortAnalyzer = () => {
@@ -83,6 +84,8 @@ export const CohortAnalyzer = () => {
 
     const containerRef = useRef(null);
     const canvasRef = useRef(null);
+    const tableFetchRequestIdRef = useRef(0);
+    const isReplacingExampleCohortsRef = useRef(false);
     const classes = useStyle();
     const { state, dispatch: cohortDispatch } = useContext(CohortStateContext);
     const hasParticipantData = useMemo(
@@ -133,6 +136,7 @@ export const CohortAnalyzer = () => {
     }
 
     async function getJoinedCohort(isReset = false) {
+        const requestId = ++tableFetchRequestIdRef.current;
         await getJoinedCohortData({
             nodeIndex,
             selectedCohorts,
@@ -141,9 +145,9 @@ export const CohortAnalyzer = () => {
             searchValue,
             isReset,
             setQueryVariable,
-            setRowData,
+            setRowData: guardSetterForRequest(setRowData, requestId, tableFetchRequestIdRef),
             location,
-            setCohortData
+            setCohortData: guardSetterForRequest(setCohortData, requestId, tableFetchRequestIdRef),
         });
     }
 
@@ -178,10 +182,9 @@ export const CohortAnalyzer = () => {
     }, [selectedChart])
 
     useEffect(() => {
-        if (selectedChart.length >= 0) {
+        if (selectedCohorts.length > 0) {
             getJoinedCohort();
         }
-
 
         setSelectedCohortSections(
             filterVennSectionsForSelectedCohorts(
@@ -193,7 +196,10 @@ export const CohortAnalyzer = () => {
 
         if (selectedCohorts.length === 0) {
             setGeneralInfo({});
-            if (shouldClearRowDataOnEmptySelection(selectedCohorts, location)) {
+            if (
+                shouldClearRowDataOnEmptySelection(selectedCohorts, location)
+                && !isReplacingExampleCohortsRef.current
+            ) {
                 setRowData([]);
             }
         }
@@ -246,6 +252,7 @@ export const CohortAnalyzer = () => {
     const handleDemoClick = () => {
         // First, clear any existing example cohorts from the state
         const exampleCohortKeys = getExampleCohortKeys();
+        isReplacingExampleCohortsRef.current = true;
 
         // Remove existing example cohorts from selected cohorts
         setSelectedCohorts(prev => prev.filter(cohortId => !exampleCohortKeys.includes(cohortId)));
@@ -260,6 +267,7 @@ export const CohortAnalyzer = () => {
         // Check if adding 3 example cohorts would exceed the 20-cohort limit
         // Only count non-example cohorts since example cohorts will be cleared/replaced
         if (!canAddExampleCohorts(state, exampleCohortKeys)) {
+            isReplacingExampleCohortsRef.current = false;
             Notification.show('Cannot add example cohorts. You have reached the maximum limit of 20 cohorts. Please delete some cohorts first.', 5000);
             return;
         }
@@ -268,11 +276,16 @@ export const CohortAnalyzer = () => {
         const totalCohorts = exampleCohorts.length;
 
 
+        const finishExampleCohortReplacement = () => {
+            isReplacingExampleCohortsRef.current = false;
+        };
+
         const handleExampleSuccess = (count) => {
             successCount++;
             if (successCount === totalCohorts) {
                 // Auto-select the newly created example cohorts
                 setSelectedCohorts(getExampleCohortKeys());
+                finishExampleCohortReplacement();
                 Notification.show(
                     `Successfully created and selected ${totalCohorts} example cohorts!\nView the results in the Venn diagram and histogram below.`,
                     7000,
@@ -282,6 +295,7 @@ export const CohortAnalyzer = () => {
         };
 
         const handleExampleError = (error) => {
+            finishExampleCohortReplacement();
             Notification.show(`Failed to create example cohorts: ${error.message}`, 5000);
         };
 

--- a/src/pages/CohortAnalyzer/__tests__/unit/cohortAnalyzerPageLogic.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/cohortAnalyzerPageLogic.test.js
@@ -8,6 +8,7 @@ import {
   canAddExampleCohorts,
   buildExploreUploadPayload,
   shouldSkipNavigateAwayModal,
+  guardSetterForRequest,
 } from '../../cohortAnalyzerPageLogic';
 
 describe('cohortAnalyzerPageLogic', () => {
@@ -150,6 +151,21 @@ describe('cohortAnalyzerPageLogic', () => {
 
     it('returns false otherwise', () => {
       expect(shouldSkipNavigateAwayModal()).toBe(false);
+    });
+  });
+
+  describe('guardSetterForRequest', () => {
+    it('calls setter only for the latest request id', () => {
+      const latestRequestIdRef = { current: 2 };
+      const setter = jest.fn();
+      const staleSetter = guardSetterForRequest(setter, 1, latestRequestIdRef);
+      const latestSetter = guardSetterForRequest(setter, 2, latestRequestIdRef);
+
+      staleSetter([]);
+      latestSetter([{ participant_id: 'P1' }]);
+
+      expect(setter).toHaveBeenCalledTimes(1);
+      expect(setter).toHaveBeenCalledWith([{ participant_id: 'P1' }]);
     });
   });
 });

--- a/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/styling/cohortAnalyzerThemeConfig.test.js
@@ -18,4 +18,11 @@ describe('cohortAnalyzerThemeConfig', () => {
     expect(firstCol.fontWeight).toBe(400);
     expect(firstCol.textDecoration).toBe('none');
   });
+
+  it('uses Inter Regular for table body Typography (cell content)', () => {
+    const body1 = cohortAnalyzerThemeConfig.tblBody.MuiTypography.body1;
+    expect(body1.fontWeight).toBe(400);
+    expect(body1.fontFamily).toBe('Inter, sans-serif');
+    expect(body1.fontSize).toBe('16px');
+  });
 });

--- a/src/pages/CohortAnalyzer/cohortAnalyzerPageLogic.js
+++ b/src/pages/CohortAnalyzer/cohortAnalyzerPageLogic.js
@@ -95,3 +95,12 @@ export function buildExploreUploadPayload(rowData) {
 export function shouldSkipNavigateAwayModal() {
   return localStorage.getItem('hideNavigateModal') === 'true';
 }
+
+/** Wraps a setter so only the latest in-flight table fetch may commit results. */
+export function guardSetterForRequest(setter, requestId, latestRequestIdRef) {
+  return (value) => {
+    if (requestId === latestRequestIdRef.current) {
+      setter(value);
+    }
+  };
+}

--- a/src/pages/CohortAnalyzer/styling/cohortAnalyzerThemeConfig.js
+++ b/src/pages/CohortAnalyzer/styling/cohortAnalyzerThemeConfig.js
@@ -81,6 +81,22 @@ export const cohortAnalyzerThemeConfig = {
                 },
             },
         },
+        // @bento-core/table renders cell values in MUI Typography (default body1).
+        // Base studies theme sets body1 to 600 — override so row text matches Inter Regular.
+        MuiTypography: {
+            ...(themeConfig.tblBody && themeConfig.tblBody.MuiTypography),
+            body1: {
+                ...(themeConfig.tblBody
+                    && themeConfig.tblBody.MuiTypography
+                    && themeConfig.tblBody.MuiTypography.body1),
+                fontFamily: 'Inter, sans-serif',
+                fontWeight: 400,
+                fontSize: '16px',
+                lineHeight: '17px',
+                letterSpacing: '0',
+                color: PRIMARY_4,
+            },
+        },
     },
     // Background of the "no match" row shown by @bento-core/table's
     // DisplayErrMsg when the table has zero rows (e.g. before a cohort is selected).


### PR DESCRIPTION
### Summary
This PR fixes two Cohort Analyzer table issues:

Row font weight — Table body cells were rendering at semibold (600) even though the theme set MuiTableCell to 400. @bento-core/table renders cell values in MUI Typography (body1), which still inherited fontWeight: 600 from the studies theme. Added a MuiTypography.body1 override in cohortAnalyzerThemeConfig.js so row text uses Inter Regular (400) as specified.
Example cohort table reset — After adding example cohorts, the table would populate and then clear a few seconds later. That was caused by a race: deselecting cohorts during replacement kicked off stale async fetches that finished after the new data loaded and called setRowData([]). Added a request-generation guard so only the latest table fetch can update rowData/cohortData, skipped fetches when no cohorts are selected, and avoided clearing row data while example cohorts are being replaced.