### PR TITLE
* removed add chart button from download png and pdf

### DIFF
--- a/src/pages/CohortAnalyzer/__tests__/unit/downloads/cohortAnalyzerDownloadAll.test.js
+++ b/src/pages/CohortAnalyzer/__tests__/unit/downloads/cohortAnalyzerDownloadAll.test.js
@@ -8,15 +8,37 @@ jest.mock('jspdf', () => ({
 
 import {
   CHART_EXPORT_PADDING_PX,
+  CHART_EXPORT_EXCLUDE_ATTR,
   buildRawCohortChartTabularRows,
   formatRowsAsTsv,
   formatRowsAsCsv,
   downloadTextFile,
+  shouldIncludeNodeInChartExport,
 } from '../../../downloads/cohortAnalyzerDownloadAll';
 
 describe('cohortAnalyzerDownloadAll', () => {
   it('exports chart padding constant', () => {
     expect(CHART_EXPORT_PADDING_PX).toBe(50);
+  });
+
+  it('exports chart exclude attribute constant', () => {
+    expect(CHART_EXPORT_EXCLUDE_ATTR).toBe('data-chart-export-exclude');
+  });
+
+  describe('shouldIncludeNodeInChartExport', () => {
+    it('excludes nodes inside chart export exclude markers', () => {
+      const root = document.createElement('div');
+      const excluded = document.createElement('button');
+      excluded.setAttribute(CHART_EXPORT_EXCLUDE_ATTR, 'true');
+      const label = document.createElement('span');
+      label.textContent = 'ADD CHART';
+      excluded.appendChild(label);
+      root.appendChild(excluded);
+
+      expect(shouldIncludeNodeInChartExport(root)).toBe(true);
+      expect(shouldIncludeNodeInChartExport(excluded)).toBe(false);
+      expect(shouldIncludeNodeInChartExport(label)).toBe(false);
+    });
   });
 
   describe('buildRawCohortChartTabularRows', () => {

--- a/src/pages/CohortAnalyzer/components/CohortAnalyzerChartArea.js
+++ b/src/pages/CohortAnalyzer/components/CohortAnalyzerChartArea.js
@@ -41,6 +41,7 @@ function AddChartToolbarButton({
             onClick={openAddChartInline}
             aria-label={ariaLabel}
             title={tooltipText || undefined}
+            data-chart-export-exclude="true"
         >
             <span className={classes.addChartButtonLabel}>ADD CHART</span>
             <span aria-hidden className={classes.addChartButtonIcon}>+</span>
@@ -285,9 +286,8 @@ export function CohortAnalyzerChartArea({
             </div>
             <div
                 className={classes.chartSummaryMain}
-                ref={chartSummaryExportRef}
             >
-                <div style={chartPreviewContentStyle}>
+                <div style={chartPreviewContentStyle} ref={chartSummaryExportRef}>
                 {topRowOrder.length > 0 && (
                     <div
                         className={classes.vennSurvivalRow}
@@ -377,6 +377,7 @@ export function CohortAnalyzerChartArea({
                 <div
                     ref={addChartScrollAnchorRef}
                     className={classes.chartSummaryHistogramFooter}
+                    data-chart-export-exclude="true"
                 >
                     <AddChartToolbarButton
                         classes={classes}

--- a/src/pages/CohortAnalyzer/downloads/cohortAnalyzerDownloadAll.js
+++ b/src/pages/CohortAnalyzer/downloads/cohortAnalyzerDownloadAll.js
@@ -4,6 +4,14 @@ import { jsPDF } from 'jspdf';
 /** White margin around captured chart area for PNG/PDF exports. */
 export const CHART_EXPORT_PADDING_PX = 50;
 
+/** Elements marked with this attribute are omitted from PNG/PDF chart captures. */
+export const CHART_EXPORT_EXCLUDE_ATTR = 'data-chart-export-exclude';
+
+export function shouldIncludeNodeInChartExport(node) {
+  if (!(node instanceof Element)) return true;
+  return !node.closest(`[${CHART_EXPORT_EXCLUDE_ATTR}]`);
+}
+
 function escapeCsvCell(value) {
   const s = String(value == null ? '' : value);
   if (/[",\n\r]/.test(s)) {
@@ -131,6 +139,7 @@ export async function downloadChartAreaAsPng(element, filename = 'cohort-analyze
       pixelRatio: 2,
       cacheBust: true,
       backgroundColor: '#ffffff',
+      filter: shouldIncludeNodeInChartExport,
     });
     const padded = await addUniformPaddingToPngDataUrl(dataUrl, CHART_EXPORT_PADDING_PX);
     const blob = await dataUrlToBlob(padded);
@@ -158,6 +167,7 @@ export async function downloadChartAreaAsPdf(element, filename = 'cohort-analyze
       pixelRatio: 2,
       cacheBust: true,
       backgroundColor: '#ffffff',
+      filter: shouldIncludeNodeInChartExport,
     });
     const paddedDataUrl = await addUniformPaddingToPngDataUrl(dataUrl, CHART_EXPORT_PADDING_PX);
     const img = new Image();


### PR DESCRIPTION
### Overview
Removed add chart button from download png and pdf from the dropdown (Download all ) button

### Change Details (Specifics)

The add chart button is automatically hidden when download png or pdf is selected

### Related Ticket(s)

C3DC-2210
